### PR TITLE
docs: architecture contract and tiered agent instructions

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,30 +1,42 @@
-# analytics-dbt — Project Rules
+# analytics-dbt — Architecture Contract
 
-## What This Is
-Product funnel analytics with dbt on BigQuery
+## Project
+Full-company analytics platform for a B2B SaaS company. dbt on BigQuery, Kimball star schema.
+Five source domains: product events, billing subscriptions, billing invoices, marketing spend, support tickets.
 
-## Non-Negotiables
-- No secrets in code, chat, or committed files
-- Conventional commits: feat:, fix:, refactor:, docs:, test:, chore:, perf:, build:, ci:, style:, revert:
-- Pre-commit hook: `git config core.hooksPath .githooks`
-- Preinstall security audit required before adding any new dependency
-- Project must be independently workable from its own repo root (no hub-only execution dependency)
+## Three-Layer Architecture
+- **staging**: 1:1 source shaping, views, `source()` refs only, `contract.enforced`
+- **intermediate**: all business logic (dedup, sessions, identity, attribution, lifecycle), views, `ref()` only
+- **marts**: Kimball star schema, tables, `contract.enforced`, conformed dimensions
+
+## Naming
+- Staging: `stg_{source}__{entity}` (double underscore)
+- Intermediate: `int_{domain}_{concept}`
+- Facts: `fct_{entity}`, Dimensions: `dim_{entity}`, Bridges: `bridge_{m2m}`
+
+## Hard Rules
+- No `select *` — explicit column lists everywhere
+- `{{ doc() }}` for any field description reused across 2+ models
+- Contracts required on all staging and marts models
+- No custom governance macros — use dbt-project-evaluator
+
+## SQL Style
+- SQLFluff for linting
+- Lowercase keywords, trailing commas, 4-space indent
+- CTEs over subqueries
 
 ## Testing
-- python3 -m unittest discover -s tests -p 'test_*.py'
-- TDD for all modules: failing test → smallest fix → green → refactor
-- Mock I/O boundaries in unit tests
-
-## Data Backend
-- Default: BigQuery (hub pipeline). See `~/Agentic/docs/integrations/bigquery-event-contract.md` for schema patterns.
-- Guardrails: partition by date, `require_partition_filter=true`, byte cap on queries, dead-letter table per dataset.
-- Choose local Postgres instead only for: relational CRUD, low-latency transactions, or offline-first apps.
-- Never store secrets, PII, or runtime state in BigQuery.
+- Primary keys: `not_null` + `unique` on every model
+- Foreign keys: `relationships` test on every FK
+- Enums: `accepted_values` on all categorical columns
+- Business rules: singular tests at layer boundaries
+- See `tests/CLAUDE.md` for categories and naming
 
 ## Git
-- **Never commit directly to main.** Create a feature branch first: `git checkout -b feat/description`
-- Push branches with `git push -u origin HEAD`, then `gh pr create`
-- Squash merge via `gh pr merge --squash --delete-branch`
-- Pre-push hook blocks direct pushes to main (primary enforcement).
-- Pre-commit blocks: .env, tokens, secrets
-- Full workflow: `~/Agentic/frameworks/engineering/GIT_BRANCH_WORKFLOW.md`
+- Never commit directly to main — feature branch + PR
+- Conventional commits: feat:, fix:, docs:, test:, refactor:, chore:
+- Squash merge via PR
+
+## Layer Details
+Each model directory has its own CLAUDE.md with layer-specific rules.
+Full documentation in `docs/layers/`.

--- a/README.md
+++ b/README.md
@@ -1,27 +1,84 @@
 # analytics-dbt
 
-Product funnel analytics with dbt on BigQuery
+Full-company analytics platform for a B2B SaaS company, built with dbt on BigQuery.
+
+Covers the full analytics lifecycle across five source domains — product events, billing, marketing, and support — through a three-layer dbt architecture into a Kimball star schema for BI consumption.
 
 ## Quick Start
 
-1. Clone and enter this project directory.
-2. Install project dependencies.
-3. Run tests:
+Prerequisites: dbt-core 1.11+, dbt-bigquery, Python 3.10+
 
 ```bash
-python3 -m unittest discover -s tests -p 'test_*.py'
+# Copy and configure profiles
+cp profiles.yml.example ~/.dbt/profiles.yml
+# Set GCP_PROJECT_ID in your environment
+
+dbt deps        # install packages
+dbt parse       # validate project structure
+dbt build       # run models + tests
 ```
 
-## Standalone Workability
+## Architecture
 
-This project is expected to be independently workable from this repo root.
+Three-layer dbt project following Kimball dimensional modeling:
 
-Minimum requirements:
-- Local tests run from this repo root.
-- CI runs the same test command.
-- Rules are documented in `CLAUDE.md` and `AGENTS.md`.
+```
+raw sources           staging               intermediate            marts
+───────────          ─────────             ──────────────          ──────
+raw_funnel     ───►  stg_*__events    ───► int_sessions       ──► fct_sessions
+raw_billing    ───►  stg_*__subs      ───► int_mrr_movements  ──► fct_account_mrr
+               ───►  stg_*__invoices  ───► int_attribution    ──► dim_users
+raw_marketing  ───►  stg_*__spend     ───► int_engagement     ──► dim_accounts
+raw_support    ───►  stg_*__tickets   ───► int_account_health ──► dim_date
+                     (view, 1:1)           (view, logic)           (table, star)
+```
 
-## Notes
+## Source Domains
 
-- Date scaffolded: 2026-03-12
-- Repository owner: joeljohn07
+| Domain | Source | Key Entities |
+|--------|--------|-------------|
+| Product | `raw_funnel.events` | Page views, signups, activations, feature usage, experiments |
+| Billing | `raw_billing.subscriptions` | Trials, upgrades, downgrades, cancellations, MRR |
+| Billing | `raw_billing.invoices` | Payments, refunds, line items |
+| Marketing | `raw_marketing.spend` | Channel spend, campaigns, impressions, clicks |
+| Support | `raw_support.tickets` | Tickets, resolution times, CSAT scores |
+
+## Directory Structure
+
+```
+.
+├── models/
+│   ├── staging/          # 1:1 source shaping (views)
+│   ├── intermediate/     # Business logic (views + 1 incremental)
+│   └── marts/            # Kimball star schema (tables)
+├── tests/
+│   ├── invariants/       # PK, not-null, enum checks
+│   ├── reconciliation/   # Cross-layer row/value checks
+│   ├── fanout/           # Grain change detection
+│   └── contracts/        # Schema contract enforcement
+├── macros/               # Reusable SQL macros
+├── seeds/                # Static reference data
+├── docs/                 # Extended documentation
+├── analyses/             # Ad-hoc analytical queries
+└── scripts/              # Utility scripts
+```
+
+## Environment Targets
+
+| Target | Dataset | Auth | Use |
+|--------|---------|------|-----|
+| dev | analytics_dev | OAuth (personal) | Local development |
+| ci | analytics_ci | Service account | CI pipeline |
+| prod | analytics | Impersonated SA | Production |
+
+## Contributing
+
+1. Create a feature branch (never commit directly to main)
+2. Follow conventional commits: `feat:`, `fix:`, `docs:`, `test:`, `refactor:`
+3. Test your changes: `dbt build --select state:modified+`
+4. Push and open a PR
+5. CI runs lint + parse + build + test
+
+## License
+
+MIT

--- a/decisions.md
+++ b/decisions.md
@@ -2,5 +2,12 @@
 
 ## 2026-03-12: Initial setup
 - Project created and scaffolded
-- Description: Product funnel analytics with dbt on BigQuery
+- Description: Full-company analytics platform with dbt on BigQuery
 - Repo: https://github.com/joeljohn07/analytics-dbt
+
+## 2026-03-13: Architecture contract + tiered agent instructions
+- Rewrote CLAUDE.md with dbt-specific three-layer architecture contract
+- Created directory-level CLAUDE.md for staging, intermediate, marts, tests (Tier 1)
+- Rewrote README.md with architecture diagram, source domains, environment targets
+- Created Tier 2 doc stubs in docs/layers/
+- Updated llms.txt with dbt references

--- a/docs/layers/dimensional-modeling-guidelines.md
+++ b/docs/layers/dimensional-modeling-guidelines.md
@@ -1,0 +1,12 @@
+# Dimensional Modeling Guidelines
+
+Reference for Kimball patterns used in the marts layer.
+
+## Conformed Dimensions
+_Shared dimension keys, grain declarations, role-playing FKs._
+
+## Fact Table Patterns
+_Transaction facts, periodic snapshots, factless facts._
+
+## Dimension Patterns
+_Slowly changing dimensions, junk dimensions, degenerate dimensions._

--- a/docs/layers/layer-contract.md
+++ b/docs/layers/layer-contract.md
@@ -1,0 +1,12 @@
+# Layer Contract
+
+Detailed rules and examples for each layer of the dbt project.
+
+## Staging
+_Detailed staging contract with examples._
+
+## Intermediate
+_Detailed intermediate contract with examples._
+
+## Marts
+_Detailed marts contract with examples._

--- a/llms.txt
+++ b/llms.txt
@@ -1,15 +1,18 @@
 # analytics-dbt — LLM Entry Point
 
 ## Read First
-1. CLAUDE.md — project rules and non-negotiables
-2. AGENTS.md — module layout and TDD requirements
-3. decisions.md — architecture decisions
+1. CLAUDE.md — architecture contract and hard rules
+2. models/*/CLAUDE.md — layer-specific rules (staging, intermediate, marts)
+3. tests/CLAUDE.md — test categories and naming
+4. decisions.md — architecture decisions
 
 ## What This Does
-Product funnel analytics with dbt on BigQuery
+Full-company analytics platform for a B2B SaaS company. dbt on BigQuery, Kimball star schema.
 
 ## Key Files
-- (fill in as project grows)
+- dbt_project.yml — project config, materialization defaults
+- packages.yml — dbt package dependencies
+- macros/generate_schema_name.sql — schema routing
 
-## Run Tests
-python3 -m unittest discover -s tests -p 'test_*.py'
+## Validate
+dbt deps && dbt parse

--- a/models/intermediate/CLAUDE.md
+++ b/models/intermediate/CLAUDE.md
@@ -1,0 +1,23 @@
+# Intermediate Layer
+
+## Purpose
+All business logic lives here. Dedup, sessionization, identity stitching, attribution, lifecycle state machines, cross-domain joins.
+
+## Conventions
+- Materialized: view (default). Use table only if query is too heavy for downstream.
+- Exception: `int_events_normalized` is incremental (merge on event_id, 36h lookback)
+- Naming: `int_{domain}_{concept}`
+- `ref()` staging or other intermediate models only — never `source()`
+- No `contract.enforced` (intermediate is internal)
+
+## What Belongs Here
+- Deduplication and normalization
+- Sessionization, identity stitching, funnel staging
+- Attribution, engagement states, experiment results
+- Subscription lifecycle, MRR movements
+- Cross-domain joins (checkout conversion, account health)
+
+## What Does Not Belong Here
+- Direct `source()` references
+- Final dimensional modeling (that belongs in marts)
+- Metric definitions

--- a/models/marts/CLAUDE.md
+++ b/models/marts/CLAUDE.md
@@ -1,0 +1,24 @@
+# Marts Layer
+
+## Purpose
+Kimball star schema. Consumer-facing facts and dimensions.
+
+## Conventions
+- Materialized: table
+- `contract.enforced: true` on all marts models
+- Naming: `fct_{entity}`, `dim_{entity}`, `bridge_{m2m}`
+- `meta` required: owner, pii (boolean), sla, tier (1-5)
+- `ref()` intermediate models only — never `source()`, never staging
+- Conformed dimensions: shared dim keys across all facts
+- Role-playing FKs use suffixed keys (e.g., `session_date_key`, `acquisition_date_key`)
+
+## What Belongs Here
+- Fact tables at declared grain (one row = one event/snapshot)
+- Dimension tables with descriptive attributes
+- Bridge tables for many-to-many relationships
+- Light joins and column selection from intermediate models
+
+## What Does Not Belong Here
+- Heavy transformations (push to intermediate)
+- Raw source references
+- Business logic beyond FK assembly

--- a/models/staging/CLAUDE.md
+++ b/models/staging/CLAUDE.md
@@ -1,0 +1,23 @@
+# Staging Layer
+
+## Purpose
+1:1 shaping of raw sources. No business logic. No joins.
+
+## Conventions
+- Materialized: view
+- Naming: `stg_{source}__{entity}` (double underscore separates source from entity)
+- Only `source()` references — never `ref()`
+- `contract.enforced: true` on all staging models
+- Shred JSON fields to flat columns (e.g., properties → typed columns)
+- Cast to canonical types (TIMESTAMP, DATE, STRING, INT64, NUMERIC)
+- Rename source columns to snake_case, no abbreviations
+
+## What Belongs Here
+- Column renaming and type casting
+- JSON shredding (properties, line_items, experiment_flags)
+- Null handling for optional fields
+
+## What Does Not Belong Here
+- Joins, aggregations, window functions, derived columns
+- Business logic or derived metrics
+- References to other models

--- a/tests/CLAUDE.md
+++ b/tests/CLAUDE.md
@@ -1,0 +1,25 @@
+# Test Rules
+
+## Categories
+Tests are organized into subdirectories:
+
+- `invariants/` — PK uniqueness, not-null, accepted_values (every model)
+- `reconciliation/` — row count and value checks across layers
+- `fanout/` — detect unintended grain changes from joins
+- `contracts/` — schema contract enforcement (marts + staging)
+
+## Naming
+- Schema tests: declared in model YAML (not_null, unique, relationships, accepted_values)
+- Singular tests: `{category}_{model}_{invariant}.sql`
+
+## Coverage
+- Every model: `not_null` + `unique` on primary key columns
+- Every FK column: `relationships` test to parent dimension
+- Every enum column: `accepted_values` with explicit allowed list
+- Layer boundaries: singular tests for business rules crossing layers
+
+## Conventions
+- Use dbt_expectations for complex assertions
+- Test descriptions required on all singular tests
+- Singular tests at staging input and marts output — not intermediate internals
+- Schema tests (PK, FK, enums) apply to every model including intermediate


### PR DESCRIPTION
## Summary
- Rewrite CLAUDE.md with three-layer dbt architecture contract (42 lines)
- Directory-level CLAUDE.md for staging, intermediate, marts, tests (23-24 lines each)
- README with architecture diagram, source domains, environment targets, contributing
- Doc stubs in docs/layers/ for detailed layer contract and dimensional modeling guidelines
- Updated llms.txt and decisions.md

## Architecture
Tiered context system:
- **Tier 0** (root CLAUDE.md): project scope, layer rules, naming, hard rules, governance
- **Tier 1** (directory CLAUDE.md): layer-specific conventions and boundaries
- **Tier 2** (docs/layers/): detailed contracts and examples (stubs for now)

## Validated
- All line count limits met
- AGENTS.md symlink resolves correctly
- `dbt parse` passes
- No internal references or sensitive content

Closes #4