### PR TITLE
feat: synthetic data generator and BigQuery upload

### DIFF
--- a/scripts/generate_synthetic_data.py
+++ b/scripts/generate_synthetic_data.py
@@ -3,11 +3,11 @@
 Generate synthetic B2B SaaS data for b2b-saas-dbt.
 
 Populates BigQuery raw source tables with realistic data:
-  - raw_funnel.events          (~8M rows, 50K users, 24 months)
-  - raw_billing.subscriptions  (~18-20K rows)
-  - raw_billing.invoices       (~14-16K rows)
+  - raw_funnel.events          (~5.5M rows, 50K users, 24 months)
+  - raw_billing.subscriptions  (~20K rows)
+  - raw_billing.invoices       (~24K rows)
   - raw_marketing.spend        (~6K rows)
-  - raw_support.tickets        (~50-55K rows)
+  - raw_support.tickets        (~87K rows)
 
 Usage:
     source .venv/bin/activate
@@ -21,6 +21,7 @@ import json
 import os
 import uuid
 from datetime import datetime, timedelta, date, timezone
+from decimal import Decimal
 from pathlib import Path
 
 import numpy as np
@@ -1007,8 +1008,7 @@ def build_subscriptions_df(account_subs):
             if isinstance(event_time, date) and not isinstance(event_time, datetime):
                 event_time = datetime.combine(event_time, datetime.min.time(),
                                              tzinfo=timezone.utc)
-            ingest_time = event_time + timedelta(seconds=rint(1, 30))
-            loaded_at = ingest_time + timedelta(seconds=rint(1, 10))
+            loaded_at = event_time + timedelta(seconds=rint(1, 40))
 
             mrr = event["mrr_amount"]
             if currency == "EUR" and mrr > 0:
@@ -1387,13 +1387,13 @@ TICKETS_SCHEMA = [
 ]
 
 
-def create_datasets(client):
+def create_datasets(client, location="EU"):
     """Create raw source datasets if they don't exist."""
     datasets = ["raw_funnel", "raw_billing", "raw_marketing", "raw_support"]
     for ds_name in datasets:
         ds_ref = bigquery.DatasetReference(client.project, ds_name)
         ds = bigquery.Dataset(ds_ref)
-        ds.location = "EU"
+        ds.location = location
         try:
             client.create_dataset(ds, exists_ok=True)
             print(f"  Dataset {ds_name}: OK")
@@ -1408,8 +1408,9 @@ def upload_table(client, dataset, table_name, df, schema,
     table_id = f"{client.project}.{dataset}.{table_name}"
     print(f"  Uploading {table_id} ({len(df):,} rows, {write_disposition})...")
 
+    df = df.copy()
+
     # Cast NUMERIC columns to Decimal so pyarrow serializes them correctly
-    from decimal import Decimal
     for field in schema:
         if field.field_type == "NUMERIC" and field.name in df.columns:
             df[field.name] = df[field.name].apply(
@@ -1460,6 +1461,8 @@ def make_parser():
                         help="Number of users to generate (default: 50000)")
     parser.add_argument("--tables", nargs="+", choices=_ALL_TABLES,
                         help="Upload only these tables (default: all)")
+    parser.add_argument("--location", default="EU",
+                        help="BigQuery dataset location (default: EU)")
     return parser
 
 
@@ -1481,7 +1484,10 @@ def main():
     print(f"  Output: {', '.join(sorted(tables))}")
     print()
 
-    # Phase 1: Users and accounts (always needed)
+    # Generate ALL data regardless of --tables to preserve rng determinism.
+    # The --tables flag only controls which tables are uploaded/saved.
+
+    # Phase 1: Users and accounts
     users = generate_users(num_users)
     users = assign_journeys(users)
     accounts = generate_accounts(users)
@@ -1489,41 +1495,36 @@ def main():
     print()
 
     # Phase 2: Events (batched in 250K-row DataFrames)
-    needs_events = "events" in tables
-    event_batches = generate_all_events(users, account_subs) if needs_events else []
-    if needs_events:
-        print()
+    event_batches = generate_all_events(users, account_subs)
+    print()
 
     # Phase 3: Billing
-    subs_df = build_subscriptions_df(account_subs) if "subscriptions" in tables else None
-    invoices_df = build_invoices_df(account_subs) if "invoices" in tables else None
-    if subs_df is not None or invoices_df is not None:
-        print()
+    subs_df = build_subscriptions_df(account_subs)
+    invoices_df = build_invoices_df(account_subs)
+    print()
 
     # Phase 4: Marketing
-    spend_df = build_marketing_spend_df() if "spend" in tables else None
-    if spend_df is not None:
-        print()
+    spend_df = build_marketing_spend_df()
+    print()
 
     # Phase 5: Support
-    tickets_df = build_support_tickets_df(users, accounts, account_subs) if "tickets" in tables else None
-    if tickets_df is not None:
-        print()
+    tickets_df = build_support_tickets_df(users, accounts, account_subs)
+    print()
 
-    # Summary
+    # Summary (only show requested tables)
     total_events = sum(len(b) for b in event_batches)
     print("=" * 60)
     print("Summary")
     print("=" * 60)
-    if needs_events:
+    if "events" in tables:
         print(f"  Events:        {total_events:>10,} rows ({len(event_batches)} batches)")
-    if subs_df is not None:
+    if "subscriptions" in tables:
         print(f"  Subscriptions: {len(subs_df):>10,} rows")
-    if invoices_df is not None:
+    if "invoices" in tables:
         print(f"  Invoices:      {len(invoices_df):>10,} rows")
-    if spend_df is not None:
+    if "spend" in tables:
         print(f"  Spend:         {len(spend_df):>10,} rows")
-    if tickets_df is not None:
+    if "tickets" in tables:
         print(f"  Tickets:       {len(tickets_df):>10,} rows")
     print()
 
@@ -1566,7 +1567,7 @@ def main():
         client = bigquery.Client(project=args.project)
 
         print("Creating datasets...")
-        create_datasets(client)
+        create_datasets(client, location=args.location)
         print()
 
         print("Uploading tables...")

--- a/scripts/tests/test_fixes.py
+++ b/scripts/tests/test_fixes.py
@@ -148,5 +148,27 @@ class TestP5TablesArgument(unittest.TestCase):
         self.assertIsNone(args.tables)
 
 
+class TestSeedDeterminism(unittest.TestCase):
+    """--tables must not affect data generation determinism."""
+
+    def _generate_subs(self):
+        """Run full generation pipeline and return first subscription_event_id."""
+        mod.rng = mod.np.random.default_rng(42)
+        users = mod.generate_users(200)
+        users = mod.assign_journeys(users)
+        accounts = mod.generate_accounts(users)
+        subs = mod.simulate_subscriptions(users, accounts)
+        # Always generate all data (mirrors the fix)
+        mod.generate_all_events(users, subs, log_interval=99999)
+        df = mod.build_subscriptions_df(subs)
+        return df.iloc[0]["subscription_event_id"] if len(df) > 0 else None
+
+    def test_subscription_ids_match_regardless_of_tables(self):
+        first = self._generate_subs()
+        second = self._generate_subs()
+        self.assertEqual(first, second,
+                         "Same seed must produce identical data regardless of --tables")
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/scripts/tests/test_upload_table.py
+++ b/scripts/tests/test_upload_table.py
@@ -1,8 +1,11 @@
-"""Tests for upload_table schema pass-through."""
+"""Tests for upload_table schema pass-through and NUMERIC conversion."""
 import unittest
+from decimal import Decimal
 from unittest.mock import MagicMock, patch, call
 import sys
 import os
+
+import pandas as pd
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 
@@ -14,20 +17,22 @@ class TestUploadTableSchemaConversion(unittest.TestCase):
     def _make_field(self, name, field_type, mode="NULLABLE"):
         return bigquery.SchemaField(name, field_type, mode=mode)
 
-    def test_schema_passed_through_unchanged(self):
-        schema = [
-            self._make_field("id", "STRING"),
-            self._make_field("properties", "STRING"),
-            self._make_field("count", "INTEGER"),
-        ]
+    def _mock_client(self):
         client = MagicMock()
         client.project = "test-project"
         job = MagicMock()
         job.result.return_value = None
         client.load_table_from_dataframe.return_value = job
         client.get_table.return_value.num_rows = 0
+        return client
 
-        import pandas as pd
+    def test_schema_passed_through_unchanged(self):
+        schema = [
+            self._make_field("id", "STRING"),
+            self._make_field("properties", "STRING"),
+            self._make_field("count", "INTEGER"),
+        ]
+        client = self._mock_client()
         df = pd.DataFrame({"id": [], "properties": [], "count": []})
 
         upload_table(client, "ds", "tbl", df, schema)
@@ -41,14 +46,7 @@ class TestUploadTableSchemaConversion(unittest.TestCase):
             self._make_field("id", "STRING"),
             self._make_field("ts", "TIMESTAMP"),
         ]
-        client = MagicMock()
-        client.project = "test-project"
-        job = MagicMock()
-        job.result.return_value = None
-        client.load_table_from_dataframe.return_value = job
-        client.get_table.return_value.num_rows = 0
-
-        import pandas as pd
+        client = self._mock_client()
         df = pd.DataFrame({"id": [], "ts": []})
 
         upload_table(client, "ds", "tbl", df, schema)
@@ -58,6 +56,34 @@ class TestUploadTableSchemaConversion(unittest.TestCase):
         types = {f.name: f.field_type for f in load_schema}
         self.assertEqual(types["id"], "STRING")
         self.assertEqual(types["ts"], "TIMESTAMP")
+
+    def test_numeric_columns_cast_to_decimal(self):
+        schema = [
+            self._make_field("id", "STRING"),
+            self._make_field("amount", "NUMERIC"),
+        ]
+        client = self._mock_client()
+        df = pd.DataFrame({"id": ["a", "b"], "amount": [49.0, 0]})
+
+        upload_table(client, "ds", "tbl", df, schema)
+
+        uploaded_df = client.load_table_from_dataframe.call_args[0][0]
+        for val in uploaded_df["amount"]:
+            self.assertIsInstance(val, Decimal)
+        self.assertEqual(uploaded_df["amount"].iloc[0], Decimal("49.0"))
+        self.assertEqual(uploaded_df["amount"].iloc[1], Decimal("0"))
+
+    def test_upload_does_not_mutate_original_df(self):
+        schema = [
+            self._make_field("id", "STRING"),
+            self._make_field("amount", "NUMERIC"),
+        ]
+        client = self._mock_client()
+        df = pd.DataFrame({"id": ["a"], "amount": [99.0]})
+
+        upload_table(client, "ds", "tbl", df, schema)
+
+        self.assertIsInstance(df["amount"].iloc[0], float)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

- Synthetic data generator (`scripts/generate_synthetic_data.py`) producing 50K users across 5 source domains
- Uploads to BigQuery with correct partitioning and clustering
- Fix for pyarrow 23 NUMERIC column serialization (float64 → Decimal cast)
- Internal naming alignment (analytics-dbt → b2b-saas-dbt)

## Tables loaded

| Dataset | Table | Rows | Partition | Clusters |
|---------|-------|------|-----------|----------|
| raw_funnel | events | 5,506,078 | event_date | event_type, platform |
| raw_billing | subscriptions | 19,814 | event_time | account_id, event_type |
| raw_billing | invoices | 23,560 | issued_at | account_id, status |
| raw_marketing | spend | 5,840 | date | channel |
| raw_support | tickets | 87,228 | created_at | account_id, category |

## Test plan

- [x] Verified all 5 tables exist in BQ with correct schemas
- [x] Verified partitioning and clustering on all tables
- [x] Tested `--tables` flag for selective upload
- [x] Confirmed pyarrow 23 / pandas 3 / numpy 2.4 compatibility