### PR TITLE
feat: staging model for raw_funnel events

### DIFF
--- a/models/staging/raw_funnel/_models.yml
+++ b/models/staging/raw_funnel/_models.yml
@@ -1,0 +1,198 @@
+version: 2
+
+models:
+  - name: stg_raw_funnel__events
+    description: >
+      Staged product events. Shreds the properties JSON column into flat
+      columns. Passes experiment_flags as-is for downstream unnesting.
+    config:
+      contract:
+        enforced: true
+      tags:
+        - staging
+    columns:
+      # --- base columns ---
+      - name: event_id
+        data_type: string
+        description: >
+          Event identifier. Not unique in staging due to ~0.5% known duplicates
+          in source data. Dedup enforced in int_events_normalized.
+        tests:
+          - not_null
+
+      - name: event_time
+        data_type: timestamp
+        description: Timestamp when the event occurred
+        tests:
+          - not_null
+
+      - name: ingest_time
+        data_type: timestamp
+        description: Timestamp when the event was ingested by the pipeline
+
+      - name: _loaded_at
+        data_type: timestamp
+        description: Timestamp when the row was loaded into the warehouse
+
+      - name: event_date
+        data_type: date
+        description: Date of the event (derived from event_time in source)
+        tests:
+          - not_null
+
+      - name: event_type
+        data_type: string
+        description: Type of event
+        tests:
+          - not_null
+          - accepted_values:
+              arguments:
+                values:
+                  - page_view
+                  - signup
+                  - activation
+                  - feature_use
+                  - paywall_view
+                  - checkout_start
+                  - upgrade_click
+                  - member_invited
+                  - member_joined
+                  - member_removed
+
+      - name: user_id
+        data_type: string
+        description: Authenticated user ID (null for anonymous events)
+
+      - name: anon_id
+        data_type: string
+        description: Anonymous visitor ID
+        tests:
+          - not_null
+
+      - name: account_id
+        data_type: string
+        description: Account ID (null for pre-signup events)
+
+      - name: platform
+        data_type: string
+        description: Platform where the event occurred
+        tests:
+          - not_null
+          - accepted_values:
+              arguments:
+                values:
+                  - web
+                  - ios
+                  - android
+
+      - name: channel
+        data_type: string
+        description: Acquisition channel
+        tests:
+          - not_null
+          - accepted_values:
+              arguments:
+                values:
+                  - organic
+                  - paid_search
+                  - paid_social
+                  - referral
+                  - email
+                  - direct
+
+      - name: plan_context
+        data_type: string
+        description: Current plan at the time of the event
+
+      - name: utm_source
+        data_type: string
+        description: UTM source parameter
+
+      - name: utm_medium
+        data_type: string
+        description: UTM medium parameter
+
+      - name: utm_campaign
+        data_type: string
+        description: UTM campaign parameter
+
+      - name: utm_term
+        data_type: string
+        description: UTM term parameter
+
+      - name: utm_content
+        data_type: string
+        description: UTM content parameter
+
+      - name: device_type
+        data_type: string
+        description: Device type (desktop, mobile, tablet)
+
+      - name: browser
+        data_type: string
+        description: Browser name
+
+      - name: os
+        data_type: string
+        description: Operating system
+
+      - name: user_agent
+        data_type: string
+        description: Raw user agent string
+
+      # --- properties JSON shred ---
+      - name: page_url
+        data_type: string
+        description: Page URL (page_view events)
+
+      - name: referrer
+        data_type: string
+        description: Referrer URL (page_view events)
+
+      - name: signup_method
+        data_type: string
+        description: Signup method (signup events)
+
+      - name: activation_action
+        data_type: string
+        description: Activation action taken (activation events)
+
+      - name: time_to_activate_hours
+        data_type: float64
+        description: Hours from signup to activation (activation events)
+
+      - name: feature_name
+        data_type: string
+        description: Feature used (feature_use events)
+
+      - name: feature_duration_seconds
+        data_type: int64
+        description: Duration of feature use in seconds (feature_use events)
+
+      - name: source_page
+        data_type: string
+        description: Page that triggered paywall view (paywall_view events)
+
+      - name: target_plan
+        data_type: string
+        description: Target plan for checkout or upgrade (checkout_start, upgrade_click events)
+
+      - name: billing_cycle
+        data_type: string
+        description: Billing cycle selected (checkout_start events)
+
+      - name: member_role
+        data_type: string
+        description: Role of member (member_joined events)
+
+      - name: member_reason
+        data_type: string
+        description: Reason for member removal (member_removed events)
+
+      # --- experiment flags ---
+      - name: experiment_flags
+        data_type: string
+        description: >
+          JSON-serialized array of experiment assignments.
+          Each element: {"experiment_id": "...", "variant": "..."}.
+          Unnested downstream in int_experiment_results.

--- a/models/staging/raw_funnel/_sources.yml
+++ b/models/staging/raw_funnel/_sources.yml
@@ -1,0 +1,29 @@
+version: 2
+
+sources:
+  - name: raw_funnel
+    database: "{{ env_var('GCP_PROJECT_ID') }}"
+    schema: raw_funnel
+    description: Product analytics event stream
+    tables:
+      - name: events
+        description: >
+          Raw product events covering the full user lifecycle: page views,
+          signups, activations, feature usage, paywall views, checkout starts,
+          upgrade clicks, and team member management.
+        config:
+          loaded_at_field: _loaded_at
+          freshness:
+            warn_after:
+              count: 24
+              period: hour
+            error_after:
+              count: 48
+              period: hour
+        columns:
+          - name: event_id
+            description: Unique event identifier
+          - name: event_time
+            description: Timestamp when the event occurred
+          - name: _loaded_at
+            description: Timestamp when the row was loaded into the warehouse

--- a/models/staging/raw_funnel/stg_raw_funnel__events.sql
+++ b/models/staging/raw_funnel/stg_raw_funnel__events.sql
@@ -1,0 +1,66 @@
+with source as (
+
+    select * from {{ source('raw_funnel', 'events') }}
+
+),
+
+renamed as (
+
+    select
+        -- identifiers
+        event_id,
+        user_id,
+        anon_id,
+        account_id,
+
+        -- timestamps
+        event_time,
+        ingest_time,
+        _loaded_at,
+        event_date,
+
+        -- event classification
+        event_type,
+        platform,
+        channel,
+        plan_context,
+
+        -- utm
+        utm_source,
+        utm_medium,
+        utm_campaign,
+        utm_term,
+        utm_content,
+
+        -- device
+        device_type,
+        browser,
+        os,
+        user_agent,
+
+        -- properties json shred (conditional on event_type, null otherwise)
+        json_value(properties, '$.page_url') as page_url,
+        json_value(properties, '$.referrer') as referrer,
+        json_value(properties, '$.signup_method') as signup_method,
+        json_value(properties, '$.activation_action') as activation_action,
+        safe_cast(
+            json_value(properties, '$.time_to_activate_hours') as float64
+        ) as time_to_activate_hours,
+        json_value(properties, '$.feature_name') as feature_name,
+        safe_cast(
+            json_value(properties, '$.duration_seconds') as int64
+        ) as feature_duration_seconds,
+        json_value(properties, '$.source_page') as source_page,
+        json_value(properties, '$.target_plan') as target_plan,
+        json_value(properties, '$.billing_cycle') as billing_cycle,
+        json_value(properties, '$.role') as member_role,
+        json_value(properties, '$.reason') as member_reason,
+
+        -- experiment flags (json string, pass through for downstream unnesting)
+        experiment_flags
+
+    from source
+
+)
+
+select * from renamed


### PR DESCRIPTION
## Summary
- Adds `stg_raw_funnel__events` — the first and most complex staging model
- Shreds `properties` JSON column into 12 flat typed columns
- Passes `experiment_flags` as-is (JSON string) for downstream unnesting
- 34 columns total (21 base + 12 JSON shred + experiment_flags)
- Contract enforced, 10 schema tests (not_null, accepted_values)

## Key decisions
- `event_id` uniqueness test removed from staging — source has ~0.5% known duplicates (dedup in `int_events_normalized`)
- `user_agent` included (1:1 source shaping)
- Source freshness configured (24h warn / 48h error) but only effective in prod target
- `accepted_values` tests use dbt 1.11 `arguments` syntax

## Test plan
- [x] `dbt build --select +stg_raw_funnel__events` — 11 PASS, 0 ERROR
- [x] Verified JSON shred via BQ query (page_url, signup_method, etc.)
- [x] Verified event_type distribution: all 10 types present, ~6M rows

Closes #12