### PR TITLE
feat: CI pipeline, schema isolation, and WIF auth

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,34 +35,11 @@ jobs:
           cache: 'pip'
           cache-dependency-path: requirements-ci.txt
 
-      - name: Install dependencies
-        run: pip install sqlfluff sqlfluff-templater-dbt dbt-core dbt-bigquery
-
-      - name: Install dbt packages
-        run: dbt deps
-
-      - name: Create dummy profile for templater
-        env:
-          GCP_PROJECT_ID: dummy-project
-        run: |
-          mkdir -p ~/.dbt
-          printf '%s\n' \
-            'b2b_saas_dbt:' \
-            '  target: ci' \
-            '  outputs:' \
-            '    ci:' \
-            '      type: bigquery' \
-            '      method: oauth' \
-            '      project: dummy-project' \
-            '      dataset: dummy_dataset' \
-            '      location: EU' \
-            '      threads: 1' \
-            > ~/.dbt/profiles.yml
+      - name: Install sqlfluff
+        run: pip install sqlfluff
 
       - name: SQLFluff lint
-        run: sqlfluff lint models/
-        env:
-          GCP_PROJECT_ID: dummy-project
+        run: sqlfluff lint models/ --templater jinja
 
       - name: Lint model names
         run: scripts/lint-model-names.sh

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,7 +60,7 @@ jobs:
             > ~/.dbt/profiles.yml
 
       - name: SQLFluff lint
-        run: sqlfluff lint models/ --dialect bigquery
+        run: sqlfluff lint models/
         env:
           GCP_PROJECT_ID: dummy-project
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,7 @@
 # ============================================================
 # AUTOMATION: CI
-# WHAT IT DOES: Validates dbt project structure on push and PR
-# WHAT IT MODIFIES: Nothing — read-only check
+# WHAT IT DOES: Lints SQL, validates naming, builds + tests all models
+# WHAT IT MODIFIES: Creates/refreshes CI BQ datasets (analytics_ci_*)
 # AUTO-COMMITS: No
 # HOW TO DISABLE: Delete this file
 # ============================================================
@@ -14,31 +14,107 @@ on:
     branches: [main]
   workflow_dispatch:
 
+concurrency:
+  group: ci-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
-
-env:
-  GCP_PROJECT_ID: ${{ secrets.GCP_PROJECT_ID }}
-  DBT_CI_KEYFILE: /tmp/dbt-ci-keyfile.json
+  id-token: write
 
 jobs:
-  validate:
+  lint:
+    name: Lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v4
+
       - uses: actions/setup-python@v5
         with:
           python-version: '3.12'
+          cache: pip
+
+      - name: Install dependencies
+        run: pip install sqlfluff sqlfluff-templater-dbt dbt-core dbt-bigquery
+
+      - name: Install dbt packages
+        run: dbt deps
+
+      - name: Create dummy profile for templater
+        env:
+          GCP_PROJECT_ID: dummy-project
+        run: |
+          mkdir -p ~/.dbt
+          printf '%s\n' \
+            'b2b_saas_dbt:' \
+            '  target: ci' \
+            '  outputs:' \
+            '    ci:' \
+            '      type: bigquery' \
+            '      method: oauth' \
+            '      project: dummy-project' \
+            '      dataset: dummy_dataset' \
+            '      location: EU' \
+            '      threads: 1' \
+            > ~/.dbt/profiles.yml
+
+      - name: SQLFluff lint
+        run: sqlfluff lint models/
+        env:
+          GCP_PROJECT_ID: dummy-project
+
+      - name: Lint model names
+        run: scripts/lint-model-names.sh
+
+  build-and-validate:
+    name: Build & Validate
+    needs: lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+          cache: pip
+
       - name: Install dbt
         run: pip install dbt-core dbt-bigquery
-      - name: Install packages
+
+      - name: Cache dbt packages
+        uses: actions/cache@v4
+        with:
+          path: dbt_packages
+          key: dbt-packages-${{ hashFiles('packages.yml') }}
+
+      - name: Install dbt packages
         run: dbt deps
+
+      - name: Authenticate to GCP (OIDC/WIF)
+        uses: google-github-actions/auth@v2
+        with:
+          workload_identity_provider: ${{ secrets.WIF_PROVIDER }}
+          service_account: ${{ secrets.WIF_SERVICE_ACCOUNT }}
+
       - name: Set up dbt profile
-        env:
-          DBT_CI_KEYFILE_JSON: ${{ secrets.DBT_CI_KEYFILE_JSON }}
         run: |
           mkdir -p ~/.dbt
           cp profiles.yml.example ~/.dbt/profiles.yml
-          echo "$DBT_CI_KEYFILE_JSON" > /tmp/dbt-ci-keyfile.json
-      - name: Validate project
-        run: dbt parse --target ci
+
+      - name: Build all models and run tests
+        run: dbt build --target ci --full-refresh
+        env:
+          GCP_PROJECT_ID: ${{ secrets.GCP_PROJECT_ID }}
+
+      - name: Run dbt-project-evaluator
+        run: dbt build --select package:dbt_project_evaluator --target ci
+        env:
+          GCP_PROJECT_ID: ${{ secrets.GCP_PROJECT_ID }}
+
+      - name: Upload manifest (push to main only)
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        uses: actions/upload-artifact@v4
+        with:
+          name: dbt-manifest
+          path: target/manifest.json
+          retention-days: 90

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,7 +60,7 @@ jobs:
             > ~/.dbt/profiles.yml
 
       - name: SQLFluff lint
-        run: sqlfluff lint models/
+        run: sqlfluff lint models/ --dialect bigquery
         env:
           GCP_PROJECT_ID: dummy-project
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,8 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: '3.12'
-          cache: pip
+          cache: 'pip'
+          cache-dependency-path: requirements-ci.txt
 
       - name: Install dependencies
         run: pip install sqlfluff sqlfluff-templater-dbt dbt-core dbt-bigquery
@@ -76,7 +77,8 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: '3.12'
-          cache: pip
+          cache: 'pip'
+          cache-dependency-path: requirements-ci.txt
 
       - name: Install dbt
         run: pip install dbt-core dbt-bigquery

--- a/.github/workflows/pr-teardown.yml
+++ b/.github/workflows/pr-teardown.yml
@@ -1,0 +1,40 @@
+# ============================================================
+# AUTOMATION: PR Teardown
+# WHAT IT DOES: Drops CI-created BQ datasets when PR closes
+# WHAT IT MODIFIES: BigQuery datasets (analytics_ci_*)
+# AUTO-COMMITS: No
+# HOW TO DISABLE: Delete this file
+# ============================================================
+name: PR Teardown
+
+on:
+  pull_request:
+    types: [closed]
+
+permissions:
+  contents: read
+  id-token: write
+
+env:
+  GCP_PROJECT_ID: ${{ secrets.GCP_PROJECT_ID }}
+
+jobs:
+  cleanup:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Authenticate to GCP (OIDC/WIF)
+        uses: google-github-actions/auth@v2
+        with:
+          workload_identity_provider: ${{ secrets.WIF_PROVIDER }}
+          service_account: ${{ secrets.WIF_SERVICE_ACCOUNT }}
+
+      - name: Set up Cloud SDK
+        uses: google-github-actions/setup-gcloud@v2
+
+      - name: Drop CI datasets
+        run: |
+          for dataset in analytics_ci_staging analytics_ci_intermediate analytics_ci_marts; do
+            echo "Dropping $dataset (if exists)..."
+            bq rm -r -f --project_id="${GCP_PROJECT_ID}" "${dataset}" 2>/dev/null || true
+          done
+          echo "CI dataset cleanup complete."

--- a/.sqlfluff
+++ b/.sqlfluff
@@ -1,0 +1,40 @@
+[sqlfluff]
+dialect = bigquery
+templater = dbt
+max_line_length = 120
+indent_unit = space
+# AM04: unknown column count — not relevant for dbt views
+# ST06: column order — enforced by review, not linter
+# RF04: keywords as identifiers — BigQuery has many reserved-word identifiers
+exclude_rules = AM04, ST06, RF04
+
+[sqlfluff:indentation]
+tab_space_size = 4
+
+[sqlfluff:layout:type:comma]
+spacing_before = touch
+line_position = trailing
+
+[sqlfluff:rules:capitalisation.keywords]
+capitalisation_policy = lower
+
+[sqlfluff:rules:capitalisation.functions]
+extended_capitalisation_policy = lower
+
+[sqlfluff:rules:capitalisation.identifiers]
+extended_capitalisation_policy = lower
+
+[sqlfluff:rules:capitalisation.types]
+extended_capitalisation_policy = lower
+
+[sqlfluff:rules:capitalisation.literals]
+capitalisation_policy = lower
+
+[sqlfluff:rules:aliasing.table]
+aliasing = explicit
+
+[sqlfluff:rules:aliasing.column]
+aliasing = explicit
+
+[sqlfluff:rules:ambiguous.column_references]
+group_by_and_order_by_style = consistent

--- a/.sqlfluffignore
+++ b/.sqlfluffignore
@@ -1,0 +1,6 @@
+dbt_packages/
+target/
+logs/
+macros/
+tests/
+.venv/

--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -35,3 +35,34 @@ models:
     marts:
       +materialized: table
       +schema: marts
+
+  dbt_project_evaluator:
+    +severity: warn
+    marts:
+      dag:
+        fct_staging_dependent_on_staging:
+          +severity: error
+        fct_staging_dependent_on_source:
+          +severity: error
+        fct_marts_or_intermediate_dependent_on_source:
+          +severity: error
+        fct_direct_join_to_source:
+          +severity: error
+        fct_source_fanout:
+          +severity: warn
+        fct_model_fanout:
+          +severity: warn
+      structure:
+        fct_model_naming_conventions:
+          +severity: error
+        fct_test_coverage:
+          +severity: warn
+        fct_documentation_coverage:
+          +severity: warn
+      governance:
+        fct_public_models_without_contract:
+          +enabled: false
+        fct_undocumented_public_models:
+          +enabled: false
+        fct_exposures_dependent_on_private_models:
+          +enabled: false

--- a/macros/generate_schema_name.sql
+++ b/macros/generate_schema_name.sql
@@ -1,7 +1,9 @@
 {% macro generate_schema_name(custom_schema_name, node) -%}
     {%- if custom_schema_name is none -%}
         {{ target.schema }}
-    {%- else -%}
+    {%- elif target.name == 'prod' -%}
         {{ custom_schema_name | trim }}
+    {%- else -%}
+        {{ target.schema }}_{{ custom_schema_name | trim }}
     {%- endif -%}
 {%- endmacro %}

--- a/profiles.yml.example
+++ b/profiles.yml.example
@@ -21,9 +21,8 @@ b2b_saas_dbt:
 
     ci:
       type: bigquery
-      method: service-account
+      method: oauth
       project: "{{ env_var('GCP_PROJECT_ID') }}"
       dataset: analytics_ci
       location: EU
       threads: 4
-      keyfile: "{{ env_var('DBT_CI_KEYFILE') }}"

--- a/requirements-ci.txt
+++ b/requirements-ci.txt
@@ -1,0 +1,4 @@
+dbt-core>=1.11.0,<1.12.0
+dbt-bigquery>=1.11.0,<1.12.0
+sqlfluff>=4.0.0,<5.0.0
+sqlfluff-templater-dbt>=4.0.0,<5.0.0

--- a/scripts/lint-model-names.sh
+++ b/scripts/lint-model-names.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Enforce dbt model naming conventions per CLAUDE.md:
+#   staging:      stg_{source}__{entity}
+#   intermediate: int_{concept}
+#   marts:        fct_|dim_|bridge_|agg_|rpt_|mart_ prefix
+
+EXIT_CODE=0
+
+check_pattern() {
+    local dir="$1"
+    local pattern="$2"
+    local label="$3"
+
+    if [[ ! -d "$dir" ]]; then
+        return
+    fi
+
+    while IFS= read -r -d '' file; do
+        basename="${file##*/}"
+        name="${basename%.sql}"
+        if ! echo "$name" | grep -qE "$pattern"; then
+            echo "FAIL: $file does not match $label pattern ($pattern)"
+            EXIT_CODE=1
+        fi
+    done < <(find "$dir" -name '*.sql' -not -name '_*' -print0)
+}
+
+check_pattern "models/staging" '^stg_[a-z]+__[a-z_]+$' "staging"
+check_pattern "models/intermediate" '^int_[a-z_]+$' "intermediate"
+check_pattern "models/marts" '^(fct|dim|bridge|agg|rpt|mart)_[a-z_]+$' "marts"
+
+if [[ $EXIT_CODE -eq 0 ]]; then
+    echo "All model names pass naming conventions."
+fi
+
+exit $EXIT_CODE


### PR DESCRIPTION
## What changed

- Rewrote `.github/workflows/ci.yml` as a 2-job pipeline:
  - **Lint** (no BQ auth): SQLFluff lint + model naming convention check
  - **Build & Validate** (WIF auth): full `dbt build --full-refresh` + dbt-project-evaluator
- Fixed `generate_schema_name` macro for environment isolation:
  - dev: `analytics_dev_staging`, `analytics_dev_intermediate`, `analytics_dev_marts`
  - ci: `analytics_ci_staging`, `analytics_ci_intermediate`, `analytics_ci_marts`
  - prod: `staging`, `intermediate`, `marts` (bare names)
- Added evaluator severity overrides in `dbt_project.yml`: DAG rules as error, coverage as warn, governance models disabled
- Added `scripts/lint-model-names.sh` for naming convention enforcement
- Added `.github/workflows/pr-teardown.yml` for CI dataset cleanup on PR close
- Switched CI auth from keyfile to OIDC/WIF (pool: `github-actions`, provider: `github-oidc`, SA: `dbt-ci`)
- Updated `profiles.yml.example` CI target from `service-account` to `oauth`
- Upload `manifest.json` artifact on push-to-main for future slim CI

## Why

CI/governance system is a prerequisite for the intermediate layer. This PR establishes the CI pipeline, environment isolation, and evaluator governance. Combined with PR #30 (SQLFluff + pre-commit), this completes the CI/governance system.

## WIF setup (GCP)

- Pool: `github-actions` (global)
- Provider: `github-oidc` (restricted to `joeljohn07` org)
- SA binding: `dbt-ci@b2b-saas-analytics.iam.gserviceaccount.com` (restricted to `joeljohn07/b2b-saas-dbt` repo)
- SA permissions: `bigquery.dataEditor` + `bigquery.jobUser`
- GitHub secrets set: `WIF_PROVIDER`, `WIF_SERVICE_ACCOUNT`, `GCP_PROJECT_ID`

## Breaking change

`generate_schema_name` macro now prefixes dev/ci datasets. After merging:
1. Run `dbt run --target dev` to create views in new `analytics_dev_*` datasets
2. Optionally drop orphaned views in old `staging` dataset

## Checklist
- [x] CI workflow: lint job (no auth) + build job (WIF auth)
- [x] Schema macro: env isolation (dev/ci prefixed, prod bare)
- [x] Evaluator: severity overrides, governance disabled
- [x] Naming script passes on all 5 staging models
- [x] PR teardown workflow for CI dataset cleanup
- [x] WIF fully configured (pool, provider, SA binding, secrets)

## Test plan
- `scripts/lint-model-names.sh` — passes on existing models
- CI pipeline will validate on this PR (lint job should pass; build job requires WIF which is now configured)

Relates to #14