### PR TITLE
chore: PR template, doc block convention, and repo settings

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,18 @@
+## What changed
+<!-- Brief description -->
+
+## Why
+<!-- Motivation, link to issue -->
+
+## Checklist
+- [ ] Correct layer directory (staging/intermediate/marts)
+- [ ] Naming convention (stg_, int_, fct_, dim_, bridge_, agg_, rpt_, mart_)
+- [ ] Materialization matches layer (staging=view, intermediate=view, marts=table)
+- [ ] PK tests: `unique` + `not_null`
+- [ ] FK tests: `relationships` on every FK column
+- [ ] Enum tests: `accepted_values` on categorical columns
+- [ ] Model + column descriptions use `{{ doc() }}` blocks
+- [ ] Contracts enforced (staging + fct_/dim_/bridge_)
+
+## Test plan
+<!-- dbt build output, test count, what was verified -->

--- a/docs/doc-block-convention.md
+++ b/docs/doc-block-convention.md
@@ -1,0 +1,30 @@
+# Doc Block Convention
+
+## Naming Patterns
+
+| Scope | Pattern | Example |
+|-------|---------|---------|
+| Shared columns | `col_{column}` | `col_user_id`, `col_currency`, `col__loaded_at` |
+| Domain-qualified columns | `col_{domain}_{column}` | `col_invoice_status`, `col_ticket_status` |
+| Model descriptions | `{model_name}` | `stg_funnel__events`, `int_events_normalized` |
+
+## Reuse Rules
+
+- Column flows unchanged through layers: reuse existing `col_` block
+- Column transforms or gains new meaning: create new block
+- Same column name, different semantics: domain-qualify (`col_{domain}_{column}`)
+
+## File Organization
+
+| File | Contents |
+|------|----------|
+| `docs/columns.md` | Shared column doc blocks |
+| `models/staging/staging.md` | Staging model descriptions |
+| `models/intermediate/intermediate.md` | Intermediate model descriptions (create when building int layer) |
+| `models/marts/marts.md` | Marts model descriptions (create when building marts layer) |
+
+## When to Create a New Doc Block
+
+1. New column appears for the first time — create `col_{column}` in `docs/columns.md`
+2. Existing column name has different meaning in new context — create `col_{domain}_{column}`
+3. New model added — create `{model_name}` block in the layer's `.md` file

--- a/scripts/configure-github.sh
+++ b/scripts/configure-github.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# One-time repo settings for joeljohn07/b2b-saas-dbt
+# Run: bash scripts/configure-github.sh
+
+REPO="joeljohn07/b2b-saas-dbt"
+
+echo "Configuring repo settings..."
+gh api repos/"$REPO" \
+  --method PATCH \
+  --field allow_squash_merge=true \
+  --field allow_merge_commit=false \
+  --field allow_rebase_merge=false \
+  --field delete_branch_on_merge=true \
+  --field squash_merge_commit_title=PR_TITLE \
+  --field squash_merge_commit_message=PR_BODY \
+  --silent
+
+echo "Configuring branch protection on main..."
+gh api repos/"$REPO"/branches/main/protection \
+  --method PUT \
+  --input - <<'JSON'
+{
+  "required_status_checks": {
+    "strict": false,
+    "contexts": ["Lint", "Build & Validate"]
+  },
+  "enforce_admins": false,
+  "required_pull_request_reviews": {
+    "required_approving_review_count": 0
+  },
+  "restrictions": null
+}
+JSON
+
+echo "Done. Verify:"
+echo "  gh api repos/$REPO --jq '.allow_squash_merge, .allow_merge_commit, .delete_branch_on_merge'"
+echo "  gh api repos/$REPO/branches/main/protection --jq '.required_status_checks.contexts'"


### PR DESCRIPTION
## What changed

- `.github/pull_request_template.md` — dbt-specific PR checklist (layer, naming, tests, contracts, doc blocks)
- `docs/doc-block-convention.md` — naming patterns (`col_`, `col_{domain}_`), reuse rules, file organization
- `scripts/configure-github.sh` — one-time repo settings: squash-only merge, delete branch on merge, branch protection requiring Lint + Build & Validate CI checks

## Why

Final piece of the CI/governance system (alongside PR #30 and PR #31). Standardizes PR review and repo merge settings.

## Test plan
- PR template: verified markdown renders correctly
- Doc convention: matches existing patterns in `docs/columns.md` and `models/staging/staging.md`
- Repo settings script: dry-read verified, run manually after merge

Relates to #14