### PR TITLE
feat: identity stitching, account memberships, and MRR movements

### DIFF
--- a/models/intermediate/billing/_models.yml
+++ b/models/intermediate/billing/_models.yml
@@ -79,3 +79,61 @@ models:
               min_value: 0
               config:
                 where: "days_since_previous_event is not null"
+
+  - name: int_mrr_movements
+    description: '{{ doc("int_mrr_movements") }}'
+    config:
+      tags:
+        - intermediate
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          combination_of_columns:
+            - account_id
+            - subscription_event_id
+    columns:
+      - name: account_id
+        description: '{{ doc("col_account_id") }}'
+        tests:
+          - not_null
+
+      - name: subscription_event_id
+        description: '{{ doc("col_subscription_event_id") }}'
+        tests:
+          - not_null
+
+      - name: subscription_id
+        description: '{{ doc("col_subscription_id") }}'
+        tests:
+          - not_null
+
+      - name: movement_date
+        description: Date of the MRR movement.
+        tests:
+          - not_null
+
+      - name: movement_type
+        description: Category of MRR change.
+        tests:
+          - not_null
+          - accepted_values:
+              values:
+                - new
+                - expansion
+                - contraction
+                - churn
+                - reactivation
+
+      - name: mrr_before
+        description: MRR amount before this movement.
+        tests:
+          - not_null
+
+      - name: mrr_after
+        description: MRR amount after this movement.
+        tests:
+          - not_null
+
+      - name: mrr_delta
+        description: Change in MRR (mrr_after - mrr_before).
+        tests:
+          - not_null

--- a/models/intermediate/billing/int_mrr_movements.sql
+++ b/models/intermediate/billing/int_mrr_movements.sql
@@ -1,4 +1,18 @@
-with lifecycle as (
+with non_trial_events as (
+
+    select
+        account_id,
+        subscription_event_id,
+        subscription_id,
+        event_type,
+        event_time,
+        mrr_amount
+    from {{ ref('int_subscription_lifecycle') }}
+    where event_type not in ('trial_start', 'trial_end')
+
+),
+
+lifecycle as (
 
     select
         account_id,
@@ -15,7 +29,7 @@ with lifecycle as (
             partition by account_id
             order by event_time
         ) as previous_event_type
-    from {{ ref('int_subscription_lifecycle') }}
+    from non_trial_events
 
 ),
 
@@ -50,7 +64,6 @@ movements as (
         mrr_amount as mrr_after,
         mrr_amount - coalesce(previous_mrr, 0) as mrr_delta
     from lifecycle
-    where event_type not in ('trial_start', 'trial_end')
 
 )
 

--- a/models/intermediate/billing/int_mrr_movements.sql
+++ b/models/intermediate/billing/int_mrr_movements.sql
@@ -22,11 +22,11 @@ lifecycle as (
         event_time,
         mrr_amount,
         lag(mrr_amount) over (
-            partition by account_id
+            partition by account_id, subscription_id
             order by event_time
         ) as previous_mrr,
         lag(event_type) over (
-            partition by account_id
+            partition by account_id, subscription_id
             order by event_time
         ) as previous_event_type
     from non_trial_events

--- a/models/intermediate/billing/int_mrr_movements.sql
+++ b/models/intermediate/billing/int_mrr_movements.sql
@@ -1,0 +1,67 @@
+with lifecycle as (
+
+    select
+        account_id,
+        subscription_event_id,
+        subscription_id,
+        event_type,
+        event_time,
+        mrr_amount,
+        lag(mrr_amount) over (
+            partition by account_id
+            order by event_time
+        ) as previous_mrr,
+        lag(event_type) over (
+            partition by account_id
+            order by event_time
+        ) as previous_event_type
+    from {{ ref('int_subscription_lifecycle') }}
+
+),
+
+movements as (
+
+    select
+        account_id,
+        subscription_event_id,
+        subscription_id,
+        event_type,
+        date(event_time) as movement_date,
+        case
+            when
+                previous_mrr is null
+                and event_type = 'subscription_start'
+                then 'new'
+            when event_type = 'reactivation'
+                then 'reactivation'
+            when event_type = 'cancellation'
+                then 'churn'
+            when
+                mrr_amount
+                > coalesce(previous_mrr, 0)
+                then 'expansion'
+            when
+                mrr_amount
+                < coalesce(previous_mrr, 0)
+                and mrr_amount > 0
+                then 'contraction'
+        end as movement_type,
+        coalesce(previous_mrr, 0) as mrr_before,
+        mrr_amount as mrr_after,
+        mrr_amount - coalesce(previous_mrr, 0) as mrr_delta
+    from lifecycle
+    where event_type not in ('trial_start', 'trial_end')
+
+)
+
+select
+    account_id,
+    subscription_event_id,
+    subscription_id,
+    movement_date,
+    movement_type,
+    mrr_before,
+    mrr_after,
+    mrr_delta
+from movements
+where movement_type is not null

--- a/models/intermediate/product/_models.yml
+++ b/models/intermediate/product/_models.yml
@@ -122,3 +122,85 @@ models:
 
       - name: experiment_flags
         description: '{{ doc("col_experiment_flags") }}'
+
+  - name: int_identity_stitched
+    description: '{{ doc("int_identity_stitched") }}'
+    config:
+      tags:
+        - intermediate
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          combination_of_columns:
+            - anon_id
+            - valid_from
+    columns:
+      - name: anon_id
+        description: '{{ doc("col_anon_id") }}'
+        tests:
+          - not_null
+
+      - name: user_id
+        description: '{{ doc("col_user_id") }}'
+        tests:
+          - not_null
+
+      - name: valid_from
+        description: Start of the identity stitch interval (inclusive).
+        tests:
+          - not_null
+
+      - name: valid_to
+        description: >
+          End of the identity stitch interval (exclusive). Null means the
+          mapping is current/open-ended.
+
+      - name: stitch_source
+        description: How the stitch was determined (last_touch or historical).
+        tests:
+          - not_null
+          - accepted_values:
+              values:
+                - last_touch
+                - historical
+
+  - name: int_account_memberships
+    description: '{{ doc("int_account_memberships") }}'
+    config:
+      tags:
+        - intermediate
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          combination_of_columns:
+            - user_id
+            - account_id
+            - valid_from
+    columns:
+      - name: user_id
+        description: '{{ doc("col_user_id") }}'
+        tests:
+          - not_null
+
+      - name: account_id
+        description: '{{ doc("col_account_id") }}'
+        tests:
+          - not_null
+
+      - name: role
+        description: '{{ doc("col_member_role") }}'
+
+      - name: valid_from
+        description: Timestamp when the user joined the account.
+        tests:
+          - not_null
+
+      - name: valid_to
+        description: >
+          Timestamp when the user was removed from the account.
+          Null means the user is still a member.
+
+      - name: membership_duration_days
+        description: Duration of membership in calendar days.
+        tests:
+          - not_null
+          - dbt_expectations.expect_column_values_to_be_between:
+              min_value: 0

--- a/models/intermediate/product/int_account_memberships.sql
+++ b/models/intermediate/product/int_account_memberships.sql
@@ -1,0 +1,53 @@
+with membership_events as (
+
+    select
+        user_id,
+        account_id,
+        event_type,
+        event_time,
+        member_role as role
+    from {{ ref('int_events_normalized') }}
+    where
+        event_type in ('member_joined', 'member_removed')
+        and user_id is not null
+        and account_id is not null
+
+),
+
+joined_events as (
+
+    select
+        user_id,
+        account_id,
+        role,
+        event_time as valid_from,
+        lead(event_time) over (
+            partition by user_id, account_id
+            order by event_time
+        ) as next_event_time,
+        lead(event_type) over (
+            partition by user_id, account_id
+            order by event_time
+        ) as next_event_type
+    from membership_events
+    where event_type = 'member_joined'
+
+)
+
+select
+    user_id,
+    account_id,
+    role,
+    valid_from,
+    case
+        when next_event_type = 'member_removed' then next_event_time
+    end as valid_to,
+    date_diff(
+        date(coalesce(
+            case when next_event_type = 'member_removed' then next_event_time end,
+            current_timestamp()
+        )),
+        date(valid_from),
+        day
+    ) as membership_duration_days
+from joined_events

--- a/models/intermediate/product/int_account_memberships.sql
+++ b/models/intermediate/product/int_account_memberships.sql
@@ -14,22 +14,37 @@ with membership_events as (
 
 ),
 
-joined_events as (
+with_next_event as (
+
+    select
+        user_id,
+        account_id,
+        event_type,
+        event_time,
+        role,
+        lead(event_type) over (
+            partition by user_id, account_id
+            order by event_time
+        ) as next_event_type,
+        lead(event_time) over (
+            partition by user_id, account_id
+            order by event_time
+        ) as next_event_time
+    from membership_events
+
+),
+
+joined_only as (
 
     select
         user_id,
         account_id,
         role,
         event_time as valid_from,
-        lead(event_time) over (
-            partition by user_id, account_id
-            order by event_time
-        ) as next_event_time,
-        lead(event_type) over (
-            partition by user_id, account_id
-            order by event_time
-        ) as next_event_type
-    from membership_events
+        case
+            when next_event_type = 'member_removed' then next_event_time
+        end as valid_to
+    from with_next_event
     where event_type = 'member_joined'
 
 )
@@ -39,15 +54,10 @@ select
     account_id,
     role,
     valid_from,
-    case
-        when next_event_type = 'member_removed' then next_event_time
-    end as valid_to,
+    valid_to,
     date_diff(
-        date(coalesce(
-            case when next_event_type = 'member_removed' then next_event_time end,
-            current_timestamp()
-        )),
+        date(coalesce(valid_to, current_timestamp())),
         date(valid_from),
         day
     ) as membership_duration_days
-from joined_events
+from joined_only

--- a/models/intermediate/product/int_identity_stitched.sql
+++ b/models/intermediate/product/int_identity_stitched.sql
@@ -46,6 +46,10 @@ intervals as (
             partition by anon_id
             order by transition_time
         ) as next_transition_time,
+        lag(transition_time) over (
+            partition by anon_id
+            order by transition_time
+        ) as prev_transition_time,
         row_number() over (
             partition by anon_id
             order by transition_time desc
@@ -59,35 +63,16 @@ with_lookback as (
     select
         anon_id,
         user_id,
-        timestamp_sub(transition_time, interval 90 day)
-            as valid_from,
+        greatest(
+            timestamp_sub(transition_time, interval 90 day),
+            coalesce(prev_transition_time, timestamp('1970-01-01'))
+        ) as valid_from,
         next_transition_time as valid_to,
         case
             when recency_rank = 1 then 'last_touch'
             else 'historical'
         end as stitch_source
     from intervals
-
-),
-
-capped as (
-
-    select
-        w.anon_id,
-        w.user_id,
-        greatest(
-            w.valid_from,
-            coalesce(
-                lag(w.valid_to) over (
-                    partition by w.anon_id
-                    order by w.valid_from
-                ),
-                w.valid_from
-            )
-        ) as valid_from,
-        w.valid_to,
-        w.stitch_source
-    from with_lookback as w
 
 )
 
@@ -97,5 +82,5 @@ select
     valid_from,
     valid_to,
     stitch_source
-from capped
+from with_lookback
 where valid_from < coalesce(valid_to, timestamp('9999-12-31'))

--- a/models/intermediate/product/int_identity_stitched.sql
+++ b/models/intermediate/product/int_identity_stitched.sql
@@ -1,0 +1,80 @@
+with authenticated_events as (
+
+    select
+        anon_id,
+        user_id,
+        event_time
+    from {{ ref('int_events_normalized') }}
+    where user_id is not null
+
+),
+
+first_auth_per_anon as (
+
+    select
+        anon_id,
+        user_id,
+        min(event_time) as first_auth_time
+    from authenticated_events
+    group by all
+
+),
+
+ranked as (
+
+    select
+        anon_id,
+        user_id,
+        first_auth_time,
+        row_number() over (
+            partition by anon_id
+            order by first_auth_time desc
+        ) as recency_rank,
+        lead(first_auth_time) over (
+            partition by anon_id
+            order by first_auth_time asc
+        ) as next_user_start
+    from first_auth_per_anon
+
+),
+
+intervals as (
+
+    select
+        anon_id,
+        user_id,
+        first_auth_time as valid_from,
+        next_user_start as valid_to,
+        case
+            when recency_rank = 1 then 'last_touch'
+            else 'historical'
+        end as stitch_source
+    from ranked
+
+),
+
+with_stitch_window as (
+
+    select
+        i.anon_id,
+        i.user_id,
+        i.valid_from,
+        i.valid_to,
+        i.stitch_source,
+        min(e.event_time) as earliest_anon_event
+    from intervals as i
+    inner join {{ ref('int_events_normalized') }} as e
+        on i.anon_id = e.anon_id
+    group by all
+
+)
+
+select
+    anon_id,
+    user_id,
+    valid_from,
+    valid_to,
+    stitch_source
+from with_stitch_window
+where
+    timestamp_diff(valid_from, earliest_anon_event, day) <= 90

--- a/models/intermediate/product/int_identity_stitched.sql
+++ b/models/intermediate/product/int_identity_stitched.sql
@@ -9,32 +9,30 @@ with authenticated_events as (
 
 ),
 
-first_auth_per_anon as (
+user_transitions as (
 
     select
         anon_id,
         user_id,
-        min(event_time) as first_auth_time
+        event_time,
+        lag(user_id) over (
+            partition by anon_id
+            order by event_time, user_id
+        ) as prev_user_id
     from authenticated_events
-    group by all
 
 ),
 
-ranked as (
+transition_starts as (
 
     select
         anon_id,
         user_id,
-        first_auth_time,
-        row_number() over (
-            partition by anon_id
-            order by first_auth_time desc
-        ) as recency_rank,
-        lead(first_auth_time) over (
-            partition by anon_id
-            order by first_auth_time asc
-        ) as next_user_start
-    from first_auth_per_anon
+        event_time as transition_time
+    from user_transitions
+    where
+        prev_user_id is null
+        or prev_user_id != user_id
 
 ),
 
@@ -43,29 +41,53 @@ intervals as (
     select
         anon_id,
         user_id,
-        first_auth_time as valid_from,
-        next_user_start as valid_to,
+        transition_time,
+        lead(transition_time) over (
+            partition by anon_id
+            order by transition_time
+        ) as next_transition_time,
+        row_number() over (
+            partition by anon_id
+            order by transition_time desc
+        ) as recency_rank
+    from transition_starts
+
+),
+
+with_lookback as (
+
+    select
+        anon_id,
+        user_id,
+        timestamp_sub(transition_time, interval 90 day)
+            as valid_from,
+        next_transition_time as valid_to,
         case
             when recency_rank = 1 then 'last_touch'
             else 'historical'
         end as stitch_source
-    from ranked
+    from intervals
 
 ),
 
-with_stitch_window as (
+capped as (
 
     select
-        i.anon_id,
-        i.user_id,
-        i.valid_from,
-        i.valid_to,
-        i.stitch_source,
-        min(e.event_time) as earliest_anon_event
-    from intervals as i
-    inner join {{ ref('int_events_normalized') }} as e
-        on i.anon_id = e.anon_id
-    group by all
+        w.anon_id,
+        w.user_id,
+        greatest(
+            w.valid_from,
+            coalesce(
+                lag(w.valid_to) over (
+                    partition by w.anon_id
+                    order by w.valid_from
+                ),
+                w.valid_from
+            )
+        ) as valid_from,
+        w.valid_to,
+        w.stitch_source
+    from with_lookback as w
 
 )
 
@@ -75,6 +97,5 @@ select
     valid_from,
     valid_to,
     stitch_source
-from with_stitch_window
-where
-    timestamp_diff(valid_from, earliest_anon_event, day) <= 90
+from capped
+where valid_from < coalesce(valid_to, timestamp('9999-12-31'))

--- a/tests/invariants/invariants_int_identity_stitched_no_overlapping_intervals.sql
+++ b/tests/invariants/invariants_int_identity_stitched_no_overlapping_intervals.sql
@@ -1,0 +1,26 @@
+-- Validates that no two identity stitch intervals overlap for the same anon_id.
+-- Half-open intervals [valid_from, valid_to) must not have any temporal overlap.
+
+{{ config(severity='error') }}
+
+with intervals as (
+
+    select
+        anon_id,
+        valid_from,
+        coalesce(valid_to, timestamp('9999-12-31')) as valid_to
+    from {{ ref('int_identity_stitched') }}
+
+)
+
+select
+    a.anon_id,
+    a.valid_from as a_valid_from,
+    a.valid_to as a_valid_to,
+    b.valid_from as b_valid_from,
+    b.valid_to as b_valid_to
+from intervals as a
+inner join intervals as b
+    on a.anon_id = b.anon_id
+    and a.valid_from < b.valid_from
+    and a.valid_to > b.valid_from

--- a/tests/invariants/invariants_int_identity_stitched_no_overlapping_intervals.sql
+++ b/tests/invariants/invariants_int_identity_stitched_no_overlapping_intervals.sql
@@ -1,7 +1,11 @@
 -- Validates that no two identity stitch intervals overlap for the same anon_id.
 -- Half-open intervals [valid_from, valid_to) must not have any temporal overlap.
 
-{{ config(severity='error') }}
+{{ config(
+    severity='error',
+    tags=['operations_alert'],
+    description='No two identity stitch intervals may overlap for the same anon_id'
+) }}
 
 with intervals as (
 

--- a/tests/reconciliation/reconciliation_int_mrr_movements_net_mrr.sql
+++ b/tests/reconciliation/reconciliation_int_mrr_movements_net_mrr.sql
@@ -1,0 +1,38 @@
+-- Validates that SUM(mrr_delta) per account equals the account's final MRR.
+-- Compares the cumulative MRR movements against the latest subscription
+-- lifecycle event's mrr_amount for each account.
+
+{{ config(severity='error') }}
+
+with movements_total as (
+
+    select
+        account_id,
+        sum(mrr_delta) as total_mrr_delta
+    from {{ ref('int_mrr_movements') }}
+    group by all
+
+),
+
+latest_lifecycle as (
+
+    select
+        account_id,
+        mrr_amount as final_mrr
+    from {{ ref('int_subscription_lifecycle') }}
+    qualify row_number() over (
+        partition by account_id
+        order by event_time desc
+    ) = 1
+
+)
+
+select
+    m.account_id,
+    m.total_mrr_delta,
+    l.final_mrr,
+    abs(m.total_mrr_delta - l.final_mrr) as difference
+from movements_total as m
+inner join latest_lifecycle as l
+    on m.account_id = l.account_id
+where abs(m.total_mrr_delta - l.final_mrr) > 0.01

--- a/tests/reconciliation/reconciliation_int_mrr_movements_net_mrr.sql
+++ b/tests/reconciliation/reconciliation_int_mrr_movements_net_mrr.sql
@@ -2,7 +2,11 @@
 -- Compares the cumulative MRR movements against the latest subscription
 -- lifecycle event's mrr_amount for each account.
 
-{{ config(severity='error') }}
+{{ config(
+    severity='error',
+    tags=['billing_validation'],
+    description='SUM(mrr_delta) must equal final MRR per account'
+) }}
 
 with movements_total as (
 

--- a/tests/reconciliation/reconciliation_int_mrr_movements_net_mrr.sql
+++ b/tests/reconciliation/reconciliation_int_mrr_movements_net_mrr.sql
@@ -22,12 +22,24 @@ latest_lifecycle as (
 
     select
         account_id,
+        subscription_id,
         mrr_amount as final_mrr
     from {{ ref('int_subscription_lifecycle') }}
+    where event_type not in ('trial_start', 'trial_end')
     qualify row_number() over (
-        partition by account_id
+        partition by account_id, subscription_id
         order by event_time desc
     ) = 1
+
+),
+
+latest_mrr_per_account as (
+
+    select
+        account_id,
+        sum(final_mrr) as final_mrr
+    from latest_lifecycle
+    group by all
 
 )
 
@@ -37,6 +49,6 @@ select
     l.final_mrr,
     abs(m.total_mrr_delta - l.final_mrr) as difference
 from movements_total as m
-inner join latest_lifecycle as l
+inner join latest_mrr_per_account as l
     on m.account_id = l.account_id
 where abs(m.total_mrr_delta - l.final_mrr) > 0.01


### PR DESCRIPTION
## Summary
- 3 tier 2 intermediate models (identity stitching, account memberships, MRR movements)
- 2 singular tests (interval overlap invariant, MRR delta reconciliation)

## Models
| Model | Grain | Upstream |
|-------|-------|----------|
| `int_identity_stitched` | anon_id x valid_from | int_events_normalized |
| `int_account_memberships` | user_id x account_id x valid_from | int_events_normalized |
| `int_mrr_movements` | account_id x subscription_event_id | int_subscription_lifecycle |

## Test plan
- [ ] `dbt parse` passes
- [ ] SQLFluff lint clean
- [ ] `dbt build` passes against BQ
- [ ] Identity intervals do not overlap per anon_id
- [ ] SUM(mrr_delta) reconciles with final MRR per account

Depends on: #33
Closes #16
Partial: #18