### PR TITLE
feat: sessions, funnel staging, and attribution models

### DIFF
--- a/models/intermediate/cross_domain/_models.yml
+++ b/models/intermediate/cross_domain/_models.yml
@@ -193,3 +193,60 @@ models:
         description: '{{ doc("col__loaded_at") }}'
         tests:
           - not_null
+
+  - name: int_attribution
+    description: '{{ doc("int_attribution") }}'
+    config:
+      tags:
+        - intermediate
+    columns:
+      - name: user_id
+        description: '{{ doc("col_user_id") }}'
+        tests:
+          - unique
+          - not_null
+
+      - name: first_touch_channel
+        description: Channel of the first touchpoint within 30 days of activation.
+        tests:
+          - not_null:
+              config:
+                where: "activation_at is not null"
+
+      - name: first_touch_source
+        description: UTM source of the first touchpoint. Null for organic users.
+
+      - name: first_touch_medium
+        description: UTM medium of the first touchpoint. Null for organic users.
+
+      - name: first_touch_campaign
+        description: UTM campaign of the first touchpoint. Null for organic users.
+
+      - name: first_touch_at
+        description: Timestamp of the first touchpoint.
+        tests:
+          - not_null
+
+      - name: last_touch_channel
+        description: Channel of the last touchpoint before activation.
+        tests:
+          - not_null
+
+      - name: last_touch_source
+        description: UTM source of the last touchpoint. Null for organic users.
+
+      - name: last_touch_medium
+        description: UTM medium of the last touchpoint. Null for organic users.
+
+      - name: last_touch_campaign
+        description: UTM campaign of the last touchpoint. Null for organic users.
+
+      - name: last_touch_at
+        description: Timestamp of the last touchpoint before activation.
+        tests:
+          - not_null
+
+      - name: activation_at
+        description: Timestamp of the user's first activation event.
+        tests:
+          - not_null

--- a/models/intermediate/cross_domain/int_attribution.sql
+++ b/models/intermediate/cross_domain/int_attribution.sql
@@ -1,0 +1,106 @@
+with events as (
+
+    select
+        coalesce(e.user_id, i.user_id) as resolved_user_id,
+        e.event_time,
+        e.event_type,
+        e.channel,
+        e.utm_source,
+        e.utm_medium,
+        e.utm_campaign
+    from {{ ref('int_events_normalized') }} as e
+    left join {{ ref('int_identity_stitched') }} as i
+        on
+            e.anon_id = i.anon_id
+            and e.event_time >= i.valid_from
+            and e.event_time < coalesce(
+                i.valid_to, timestamp('9999-12-31')
+            )
+    where coalesce(e.user_id, i.user_id) is not null
+
+),
+
+activations as (
+
+    select
+        resolved_user_id,
+        min(event_time) as activation_at
+    from events
+    where event_type = 'activation'
+    group by all
+
+),
+
+attribution_window as (
+
+    select
+        e.resolved_user_id,
+        e.event_time,
+        e.channel,
+        e.utm_source,
+        e.utm_medium,
+        e.utm_campaign,
+        a.activation_at
+    from events as e
+    inner join activations as a
+        on e.resolved_user_id = a.resolved_user_id
+    where
+        e.event_time <= a.activation_at
+        and e.event_time >= timestamp_sub(
+            a.activation_at, interval 30 day
+        )
+
+),
+
+first_touch as (
+
+    select
+        resolved_user_id,
+        channel as first_touch_channel,
+        utm_source as first_touch_source,
+        utm_medium as first_touch_medium,
+        utm_campaign as first_touch_campaign,
+        event_time as first_touch_at
+    from attribution_window
+    qualify row_number() over (
+        partition by resolved_user_id
+        order by event_time asc
+    ) = 1
+
+),
+
+last_touch as (
+
+    select
+        resolved_user_id,
+        channel as last_touch_channel,
+        utm_source as last_touch_source,
+        utm_medium as last_touch_medium,
+        utm_campaign as last_touch_campaign,
+        event_time as last_touch_at
+    from attribution_window
+    qualify row_number() over (
+        partition by resolved_user_id
+        order by event_time desc
+    ) = 1
+
+)
+
+select
+    f.resolved_user_id as user_id,
+    f.first_touch_channel,
+    f.first_touch_source,
+    f.first_touch_medium,
+    f.first_touch_campaign,
+    f.first_touch_at,
+    l.last_touch_channel,
+    l.last_touch_source,
+    l.last_touch_medium,
+    l.last_touch_campaign,
+    l.last_touch_at,
+    a.activation_at
+from first_touch as f
+inner join last_touch as l
+    on f.resolved_user_id = l.resolved_user_id
+inner join activations as a
+    on f.resolved_user_id = a.resolved_user_id

--- a/models/intermediate/cross_domain/int_attribution.sql
+++ b/models/intermediate/cross_domain/int_attribution.sql
@@ -45,7 +45,7 @@ attribution_window as (
     inner join activations as a
         on e.resolved_user_id = a.resolved_user_id
     where
-        e.event_time <= a.activation_at
+        e.event_time < a.activation_at
         and e.event_time >= timestamp_sub(
             a.activation_at, interval 30 day
         )

--- a/models/intermediate/product/_models.yml
+++ b/models/intermediate/product/_models.yml
@@ -310,3 +310,5 @@ models:
 
       - name: is_current_stage
         description: Whether this is the user's highest funnel stage.
+        tests:
+          - not_null

--- a/models/intermediate/product/_models.yml
+++ b/models/intermediate/product/_models.yml
@@ -204,3 +204,109 @@ models:
           - not_null
           - dbt_expectations.expect_column_values_to_be_between:
               min_value: 0
+
+  - name: int_sessions
+    description: '{{ doc("int_sessions") }}'
+    config:
+      tags:
+        - intermediate
+    columns:
+      - name: session_id
+        description: Deterministic hash of anon_id and first event ID.
+        tests:
+          - unique
+          - not_null
+
+      - name: anon_id
+        description: '{{ doc("col_anon_id") }}'
+        tests:
+          - not_null
+
+      - name: stitched_user_id
+        description: Authenticated user ID resolved via identity stitching. Null for anonymous sessions.
+
+      - name: session_start_at
+        description: Timestamp of the first event in the session.
+        tests:
+          - not_null
+
+      - name: session_end_at
+        description: Timestamp of the last event in the session.
+        tests:
+          - not_null
+
+      - name: session_duration_seconds
+        description: Duration of session in seconds.
+        tests:
+          - not_null
+          - dbt_expectations.expect_column_values_to_be_between:
+              min_value: 0
+
+      - name: event_count
+        description: Number of events in the session.
+        tests:
+          - not_null
+          - dbt_expectations.expect_column_values_to_be_between:
+              min_value: 1
+
+      - name: page_view_count
+        description: Number of page_view events in the session.
+
+      - name: utm_source
+        description: '{{ doc("col_utm_source") }}'
+
+      - name: utm_medium
+        description: '{{ doc("col_utm_medium") }}'
+
+      - name: utm_campaign
+        description: '{{ doc("col_utm_campaign") }}'
+
+      - name: platform
+        description: '{{ doc("col_platform") }}'
+
+      - name: device_type
+        description: '{{ doc("col_device_type") }}'
+
+      - name: browser
+        description: '{{ doc("col_browser") }}'
+
+      - name: session_date
+        description: Date of the session start.
+        tests:
+          - not_null
+
+  - name: int_funnel_staged
+    description: '{{ doc("int_funnel_staged") }}'
+    config:
+      tags:
+        - intermediate
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          combination_of_columns:
+            - user_id
+            - stage
+    columns:
+      - name: user_id
+        description: '{{ doc("col_user_id") }}'
+        tests:
+          - not_null
+
+      - name: stage
+        description: Funnel stage name.
+        tests:
+          - not_null
+          - accepted_values:
+              values:
+                - page_view
+                - signup
+                - activation
+                - feature_use
+                - checkout_start
+
+      - name: stage_reached_at
+        description: Timestamp when this funnel stage was first reached.
+        tests:
+          - not_null
+
+      - name: is_current_stage
+        description: Whether this is the user's highest funnel stage.

--- a/models/intermediate/product/int_funnel_staged.sql
+++ b/models/intermediate/product/int_funnel_staged.sql
@@ -1,0 +1,74 @@
+with events as (
+
+    select
+        e.event_type,
+        e.event_time,
+        coalesce(e.user_id, i.user_id) as resolved_user_id
+    from {{ ref('int_events_normalized') }} as e
+    left join {{ ref('int_identity_stitched') }} as i
+        on
+            e.anon_id = i.anon_id
+            and e.event_time >= i.valid_from
+            and e.event_time < coalesce(
+                i.valid_to, timestamp('9999-12-31')
+            )
+    where e.event_type in (
+        'page_view',
+        'signup',
+        'activation',
+        'feature_use',
+        'checkout_start'
+    )
+
+),
+
+stage_mapping as (
+
+    select
+        resolved_user_id,
+        event_type,
+        event_time,
+        case event_type
+            when 'page_view' then 1
+            when 'signup' then 2
+            when 'activation' then 3
+            when 'feature_use' then 4
+            when 'checkout_start' then 5
+        end as stage_ordinal
+    from events
+    where resolved_user_id is not null
+
+),
+
+user_max_stage as (
+
+    select
+        resolved_user_id,
+        max(stage_ordinal) as max_stage_ordinal
+    from stage_mapping
+    group by all
+
+),
+
+stages_reached as (
+
+    select
+        s.resolved_user_id as user_id,
+        s.event_type as stage,
+        s.stage_ordinal,
+        min(s.event_time) as stage_reached_at,
+        u.max_stage_ordinal
+    from stage_mapping as s
+    inner join user_max_stage as u
+        on s.resolved_user_id = u.resolved_user_id
+    where s.stage_ordinal <= u.max_stage_ordinal
+    group by all
+
+)
+
+select
+    user_id,
+    stage,
+    stage_reached_at,
+    stage_ordinal = max_stage_ordinal as is_current_stage
+from stages_reached

--- a/models/intermediate/product/int_sessions.sql
+++ b/models/intermediate/product/int_sessions.sql
@@ -38,8 +38,8 @@ session_boundaries as (
                     then 1
                 when
                     timestamp_diff(
-                        event_time, prev_event_time, minute
-                    ) > 30
+                        event_time, prev_event_time, second
+                    ) > 1800
                     then 1
                 else 0
             end
@@ -67,7 +67,7 @@ first_event_per_session as (
     from session_boundaries
     qualify row_number() over (
         partition by anon_id, session_seq
-        order by event_time asc
+        order by event_time asc, event_id asc
     ) = 1
 
 ),

--- a/models/intermediate/product/int_sessions.sql
+++ b/models/intermediate/product/int_sessions.sql
@@ -1,0 +1,156 @@
+with events as (
+
+    select
+        event_id,
+        anon_id,
+        event_time,
+        event_type,
+        platform,
+        device_type,
+        browser,
+        utm_source,
+        utm_medium,
+        utm_campaign,
+        lag(event_time) over (
+            partition by anon_id
+            order by event_time
+        ) as prev_event_time
+    from {{ ref('int_events_normalized') }}
+
+),
+
+session_boundaries as (
+
+    select
+        event_id,
+        anon_id,
+        event_time,
+        event_type,
+        platform,
+        device_type,
+        browser,
+        utm_source,
+        utm_medium,
+        utm_campaign,
+        case
+            when prev_event_time is null
+                then 1
+            when
+                timestamp_diff(
+                    event_time, prev_event_time, minute
+                ) > 30
+                then 1
+            else 0
+        end as is_new_session,
+        sum(
+            case
+                when prev_event_time is null
+                    then 1
+                when
+                    timestamp_diff(
+                        event_time, prev_event_time, minute
+                    ) > 30
+                    then 1
+                else 0
+            end
+        ) over (
+            partition by anon_id
+            order by event_time
+            rows unbounded preceding
+        ) as session_seq
+    from events
+
+),
+
+session_agg as (
+
+    select
+        anon_id,
+        session_seq,
+        to_hex(md5(concat(
+            anon_id,
+            min(event_id)
+        ))) as session_id,
+        min(event_time) as session_start_at,
+        max(event_time) as session_end_at,
+        timestamp_diff(
+            max(event_time), min(event_time), second
+        ) as session_duration_seconds,
+        count(*) as event_count,
+        countif(event_type = 'page_view') as page_view_count,
+        first_value(utm_source) over (
+            partition by anon_id, session_seq
+            order by event_time
+        ) as utm_source,
+        first_value(utm_medium) over (
+            partition by anon_id, session_seq
+            order by event_time
+        ) as utm_medium,
+        first_value(utm_campaign) over (
+            partition by anon_id, session_seq
+            order by event_time
+        ) as utm_campaign,
+        first_value(platform) over (
+            partition by anon_id, session_seq
+            order by event_time
+        ) as platform,
+        first_value(device_type) over (
+            partition by anon_id, session_seq
+            order by event_time
+        ) as device_type,
+        first_value(browser) over (
+            partition by anon_id, session_seq
+            order by event_time
+        ) as browser,
+        date(min(event_time)) as session_date
+    from session_boundaries
+    group by all
+
+),
+
+with_identity as (
+
+    select
+        s.session_id,
+        s.anon_id,
+        i.user_id as stitched_user_id,
+        s.session_start_at,
+        s.session_end_at,
+        s.session_duration_seconds,
+        s.event_count,
+        s.page_view_count,
+        s.utm_source,
+        s.utm_medium,
+        s.utm_campaign,
+        s.platform,
+        s.device_type,
+        s.browser,
+        s.session_date
+    from session_agg as s
+    left join {{ ref('int_identity_stitched') }} as i
+        on
+            s.anon_id = i.anon_id
+            and s.session_start_at >= i.valid_from
+            and s.session_start_at < coalesce(
+                i.valid_to, timestamp('9999-12-31')
+            )
+
+)
+
+select
+    session_id,
+    anon_id,
+    stitched_user_id,
+    session_start_at,
+    session_end_at,
+    session_duration_seconds,
+    event_count,
+    page_view_count,
+    utm_source,
+    utm_medium,
+    utm_campaign,
+    platform,
+    device_type,
+    browser,
+    session_date
+from with_identity

--- a/models/intermediate/product/int_sessions.sql
+++ b/models/intermediate/product/int_sessions.sql
@@ -32,16 +32,6 @@ session_boundaries as (
         utm_source,
         utm_medium,
         utm_campaign,
-        case
-            when prev_event_time is null
-                then 1
-            when
-                timestamp_diff(
-                    event_time, prev_event_time, minute
-                ) > 30
-                then 1
-            else 0
-        end as is_new_session,
         sum(
             case
                 when prev_event_time is null
@@ -62,15 +52,31 @@ session_boundaries as (
 
 ),
 
+first_event_per_session as (
+
+    select
+        anon_id,
+        session_seq,
+        event_id as first_event_id,
+        utm_source,
+        utm_medium,
+        utm_campaign,
+        platform,
+        device_type,
+        browser
+    from session_boundaries
+    qualify row_number() over (
+        partition by anon_id, session_seq
+        order by event_time asc
+    ) = 1
+
+),
+
 session_agg as (
 
     select
         anon_id,
         session_seq,
-        to_hex(md5(concat(
-            anon_id,
-            min(event_id)
-        ))) as session_id,
         min(event_time) as session_start_at,
         max(event_time) as session_end_at,
         timestamp_diff(
@@ -78,33 +84,37 @@ session_agg as (
         ) as session_duration_seconds,
         count(*) as event_count,
         countif(event_type = 'page_view') as page_view_count,
-        first_value(utm_source) over (
-            partition by anon_id, session_seq
-            order by event_time
-        ) as utm_source,
-        first_value(utm_medium) over (
-            partition by anon_id, session_seq
-            order by event_time
-        ) as utm_medium,
-        first_value(utm_campaign) over (
-            partition by anon_id, session_seq
-            order by event_time
-        ) as utm_campaign,
-        first_value(platform) over (
-            partition by anon_id, session_seq
-            order by event_time
-        ) as platform,
-        first_value(device_type) over (
-            partition by anon_id, session_seq
-            order by event_time
-        ) as device_type,
-        first_value(browser) over (
-            partition by anon_id, session_seq
-            order by event_time
-        ) as browser,
         date(min(event_time)) as session_date
     from session_boundaries
     group by all
+
+),
+
+sessions_enriched as (
+
+    select
+        to_hex(md5(concat(
+            a.anon_id,
+            f.first_event_id
+        ))) as session_id,
+        a.anon_id,
+        a.session_start_at,
+        a.session_end_at,
+        a.session_duration_seconds,
+        a.event_count,
+        a.page_view_count,
+        f.utm_source,
+        f.utm_medium,
+        f.utm_campaign,
+        f.platform,
+        f.device_type,
+        f.browser,
+        a.session_date
+    from session_agg as a
+    inner join first_event_per_session as f
+        on
+            a.anon_id = f.anon_id
+            and a.session_seq = f.session_seq
 
 ),
 
@@ -126,7 +136,7 @@ with_identity as (
         s.device_type,
         s.browser,
         s.session_date
-    from session_agg as s
+    from sessions_enriched as s
     left join {{ ref('int_identity_stitched') }} as i
         on
             s.anon_id = i.anon_id

--- a/tests/invariants/invariants_int_funnel_staged_one_current.sql
+++ b/tests/invariants/invariants_int_funnel_staged_one_current.sql
@@ -1,6 +1,10 @@
 -- Validates that each user has exactly one is_current_stage = true row.
 
-{{ config(severity='error') }}
+{{ config(
+    severity='error',
+    tags=['operations_alert'],
+    description='Validates that each user has exactly one is_current_stage = true row.'
+) }}
 
 select
     user_id,

--- a/tests/invariants/invariants_int_funnel_staged_one_current.sql
+++ b/tests/invariants/invariants_int_funnel_staged_one_current.sql
@@ -1,0 +1,10 @@
+-- Validates that each user has exactly one is_current_stage = true row.
+
+{{ config(severity='error') }}
+
+select
+    user_id,
+    countif(is_current_stage) as current_stage_count
+from {{ ref('int_funnel_staged') }}
+group by all
+having countif(is_current_stage) != 1

--- a/tests/invariants/invariants_int_funnel_staged_ordering.sql
+++ b/tests/invariants/invariants_int_funnel_staged_ordering.sql
@@ -1,0 +1,24 @@
+-- Validates that every user with an activation stage also has a signup stage.
+-- Funnel ordering invariant: activation requires signup first.
+
+{{ config(severity='error') }}
+
+with user_stages as (
+
+    select
+        user_id,
+        max(case when stage = 'activation' then 1 else 0 end)
+            as has_activation,
+        max(case when stage = 'signup' then 1 else 0 end)
+            as has_signup
+    from {{ ref('int_funnel_staged') }}
+    group by all
+
+)
+
+select
+    user_id,
+    has_activation,
+    has_signup
+from user_stages
+where has_activation = 1 and has_signup = 0

--- a/tests/invariants/invariants_int_funnel_staged_ordering.sql
+++ b/tests/invariants/invariants_int_funnel_staged_ordering.sql
@@ -1,7 +1,11 @@
 -- Validates that every user with an activation stage also has a signup stage.
 -- Funnel ordering invariant: activation requires signup first.
 
-{{ config(severity='error') }}
+{{ config(
+    severity='error',
+    tags=['operations_alert'],
+    description='Validates that every user with an activation stage also has a signup stage.'
+) }}
 
 with user_stages as (
 

--- a/tests/invariants/invariants_int_sessions_no_overlap.sql
+++ b/tests/invariants/invariants_int_sessions_no_overlap.sql
@@ -1,0 +1,18 @@
+-- Validates that no two sessions overlap for the same anon_id.
+-- Session time ranges [session_start_at, session_end_at] must not overlap.
+
+{{ config(severity='error') }}
+
+select
+    a.anon_id,
+    a.session_id as session_a,
+    b.session_id as session_b,
+    a.session_start_at as a_start,
+    a.session_end_at as a_end,
+    b.session_start_at as b_start,
+    b.session_end_at as b_end
+from {{ ref('int_sessions') }} as a
+inner join {{ ref('int_sessions') }} as b
+    on a.anon_id = b.anon_id
+    and a.session_id < b.session_id
+    and a.session_end_at > b.session_start_at

--- a/tests/invariants/invariants_int_sessions_no_overlap.sql
+++ b/tests/invariants/invariants_int_sessions_no_overlap.sql
@@ -1,7 +1,11 @@
 -- Validates that no two sessions overlap for the same anon_id.
 -- Session time ranges [session_start_at, session_end_at] must not overlap.
 
-{{ config(severity='error') }}
+{{ config(
+    severity='error',
+    tags=['operations_alert'],
+    description='Validates that no two sessions overlap for the same anon_id.'
+) }}
 
 select
     a.anon_id,

--- a/tests/invariants/invariants_int_sessions_no_overlap.sql
+++ b/tests/invariants/invariants_int_sessions_no_overlap.sql
@@ -18,5 +18,5 @@ select
 from {{ ref('int_sessions') }} as a
 inner join {{ ref('int_sessions') }} as b
     on a.anon_id = b.anon_id
-    and a.session_id < b.session_id
+    and a.session_start_at < b.session_start_at
     and a.session_end_at > b.session_start_at


### PR DESCRIPTION
## Summary
- 3 tier 3 intermediate models (sessions, funnel staging, attribution)
- 3 singular tests (session overlap, funnel current stage, funnel ordering)

## Models
| Model | Grain | Upstream |
|-------|-------|----------|
| `int_sessions` | session_id | int_events_normalized + int_identity_stitched |
| `int_funnel_staged` | user_id x stage | int_events_normalized + int_identity_stitched |
| `int_attribution` | user_id | int_events_normalized + int_identity_stitched |

## Test plan
- [ ] `dbt parse` passes
- [ ] SQLFluff lint clean
- [ ] `dbt build` passes against BQ
- [ ] No overlapping sessions per anon_id
- [ ] Exactly one current funnel stage per user
- [ ] Every activated user has signup stage

Depends on: #34
Closes #17
Partial: #19