### PR TITLE
feat: engagement states and experiment results models

### DIFF
--- a/models/intermediate/engagement/_models.yml
+++ b/models/intermediate/engagement/_models.yml
@@ -1,0 +1,97 @@
+version: 2
+
+models:
+  - name: int_engagement_states
+    description: '{{ doc("int_engagement_states") }}'
+    config:
+      tags:
+        - intermediate
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          combination_of_columns:
+            - user_id
+            - snapshot_week_start
+    columns:
+      - name: user_id
+        description: '{{ doc("col_user_id") }}'
+        tests:
+          - not_null
+
+      - name: snapshot_week_start
+        description: Monday start date of the snapshot week.
+        tests:
+          - not_null
+
+      - name: engagement_state
+        description: >
+          Weekly engagement classification: pre_active (before activation),
+          active (activity within 14d), dormant (14-42d), disengaged (42d+).
+        tests:
+          - not_null
+          - accepted_values:
+              values:
+                - pre_active
+                - active
+                - dormant
+                - disengaged
+
+      - name: is_re_engaged
+        description: >
+          Whether the user transitioned from dormant or disengaged to active
+          this week.
+        tests:
+          - not_null
+
+      - name: days_since_last_activity
+        description: Calendar days since the user's last activity as of snapshot week.
+
+      - name: last_activity_at
+        description: Timestamp of the user's most recent activity before snapshot week.
+
+  - name: int_experiment_results
+    description: '{{ doc("int_experiment_results") }}'
+    config:
+      tags:
+        - intermediate
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          combination_of_columns:
+            - user_id
+            - experiment_id
+    columns:
+      - name: user_id
+        description: '{{ doc("col_user_id") }}'
+        tests:
+          - not_null
+
+      - name: experiment_id
+        description: Experiment identifier from experiment_flags JSON.
+        tests:
+          - not_null
+
+      - name: variant
+        description: Experiment variant assigned to the user.
+        tests:
+          - not_null
+
+      - name: first_exposure_at
+        description: Timestamp of the user's first exposure to the experiment.
+        tests:
+          - not_null
+
+      - name: converted
+        description: Whether the user activated after experiment exposure.
+        tests:
+          - not_null
+
+      - name: conversion_at
+        description: Timestamp of activation after exposure. Null if not converted.
+
+      - name: exposure_duration_hours
+        description: >
+          Hours between first and last exposure event. Only rows with
+          exposure_duration_hours >= 24 are included (24h exclusion rule).
+        tests:
+          - not_null
+          - dbt_expectations.expect_column_values_to_be_between:
+              min_value: 24

--- a/models/intermediate/engagement/int_engagement_states.sql
+++ b/models/intermediate/engagement/int_engagement_states.sql
@@ -1,0 +1,159 @@
+with events as (
+
+    select
+        coalesce(e.user_id, i.user_id) as resolved_user_id,
+        e.event_time,
+        e.event_type
+    from {{ ref('int_events_normalized') }} as e
+    left join {{ ref('int_identity_stitched') }} as i
+        on
+            e.anon_id = i.anon_id
+            and e.event_time >= i.valid_from
+            and e.event_time < coalesce(
+                i.valid_to, timestamp('9999-12-31')
+            )
+    where coalesce(e.user_id, i.user_id) is not null
+
+),
+
+activations as (
+
+    select
+        resolved_user_id,
+        min(event_time) as activation_at
+    from events
+    where event_type = 'activation'
+    group by all
+
+),
+
+week_spine as (
+
+    select week_start
+    from
+        unnest(
+            generate_date_array(
+                (select date_trunc(min(date(event_time)), week (monday)) from events),
+                current_date(),
+                interval 1 week
+            )
+        ) as week_start
+
+),
+
+users as (
+
+    select distinct resolved_user_id
+    from events
+
+),
+
+user_weeks as (
+
+    select
+        u.resolved_user_id as user_id,
+        w.week_start as snapshot_week_start
+    from users as u
+    cross join week_spine as w
+
+),
+
+last_activity as (
+
+    select
+        uw.user_id,
+        uw.snapshot_week_start,
+        max(e.event_time) as last_activity_at
+    from user_weeks as uw
+    left join events as e
+        on
+            uw.user_id = e.resolved_user_id
+            and date(e.event_time) <= date_add(
+                uw.snapshot_week_start, interval 6 day
+            )
+    group by all
+
+),
+
+classified as (
+
+    select
+        la.user_id,
+        la.snapshot_week_start,
+        la.last_activity_at,
+        a.activation_at,
+        case
+            when la.last_activity_at is null
+                then date_diff(
+                    la.snapshot_week_start, date('2024-01-01'), day
+                )
+            else date_diff(
+                la.snapshot_week_start, date(la.last_activity_at), day
+            )
+        end as days_since_last_activity,
+        case
+            when
+                a.activation_at is null
+                or a.activation_at > timestamp(
+                    date_add(la.snapshot_week_start, interval 6 day)
+                )
+                then 'pre_active'
+            when
+                la.last_activity_at is not null
+                and date_diff(
+                    la.snapshot_week_start, date(la.last_activity_at), day
+                ) <= 14
+                then 'active'
+            when
+                la.last_activity_at is not null
+                and date_diff(
+                    la.snapshot_week_start, date(la.last_activity_at), day
+                ) <= 42
+                then 'dormant'
+            else 'disengaged'
+        end as engagement_state,
+        lag(
+            case
+                when
+                    a.activation_at is null
+                    or a.activation_at > timestamp(
+                        date_add(la.snapshot_week_start, interval 6 day)
+                    )
+                    then 'pre_active'
+                when
+                    la.last_activity_at is not null
+                    and date_diff(
+                        la.snapshot_week_start,
+                        date(la.last_activity_at),
+                        day
+                    ) <= 14
+                    then 'active'
+                when
+                    la.last_activity_at is not null
+                    and date_diff(
+                        la.snapshot_week_start,
+                        date(la.last_activity_at),
+                        day
+                    ) <= 42
+                    then 'dormant'
+                else 'disengaged'
+            end
+        ) over (
+            partition by la.user_id
+            order by la.snapshot_week_start
+        ) as previous_state
+    from last_activity as la
+    left join activations as a
+        on la.user_id = a.resolved_user_id
+
+)
+
+select
+    user_id,
+    snapshot_week_start,
+    engagement_state,
+    previous_state in ('dormant', 'disengaged')
+    and engagement_state = 'active' as is_re_engaged,
+    days_since_last_activity,
+    last_activity_at
+from classified

--- a/models/intermediate/engagement/int_experiment_results.sql
+++ b/models/intermediate/engagement/int_experiment_results.sql
@@ -1,0 +1,95 @@
+with events_with_flags as (
+
+    select
+        coalesce(e.user_id, i.user_id) as resolved_user_id,
+        e.event_time,
+        e.event_type,
+        e.experiment_flags
+    from {{ ref('int_events_normalized') }} as e
+    left join {{ ref('int_identity_stitched') }} as i
+        on
+            e.anon_id = i.anon_id
+            and e.event_time >= i.valid_from
+            and e.event_time < coalesce(
+                i.valid_to, timestamp('9999-12-31')
+            )
+    where
+        e.experiment_flags is not null
+        and coalesce(e.user_id, i.user_id) is not null
+
+),
+
+unnested as (
+
+    select
+        e.resolved_user_id,
+        e.event_time,
+        e.event_type,
+        json_extract_scalar(flag, '$.experiment_id') as experiment_id,
+        json_extract_scalar(flag, '$.variant') as variant
+    from events_with_flags as e
+    cross join unnest(
+        json_extract_array(e.experiment_flags, '$')
+    ) as flag
+
+),
+
+first_exposure as (
+
+    select
+        resolved_user_id,
+        experiment_id,
+        variant,
+        min(event_time) as first_exposure_at,
+        max(event_time) as last_exposure_at
+    from unnested
+    group by all
+
+),
+
+conversions as (
+
+    select
+        f.resolved_user_id,
+        f.experiment_id,
+        min(e.event_time) as conversion_at
+    from first_exposure as f
+    inner join events_with_flags as e
+        on
+            f.resolved_user_id = e.resolved_user_id
+            and e.event_type = 'activation'
+            and f.first_exposure_at < e.event_time
+    group by all
+
+),
+
+results as (
+
+    select
+        f.resolved_user_id as user_id,
+        f.experiment_id,
+        f.variant,
+        f.first_exposure_at,
+        c.conversion_at is not null as converted,
+        c.conversion_at,
+        timestamp_diff(
+            f.last_exposure_at, f.first_exposure_at, hour
+        ) as exposure_duration_hours
+    from first_exposure as f
+    left join conversions as c
+        on
+            f.resolved_user_id = c.resolved_user_id
+            and f.experiment_id = c.experiment_id
+
+)
+
+select
+    user_id,
+    experiment_id,
+    variant,
+    first_exposure_at,
+    converted,
+    conversion_at,
+    exposure_duration_hours
+from results
+where exposure_duration_hours >= 24


### PR DESCRIPTION
## Summary
- 2 tier 3 engagement intermediate models
- Engagement states: weekly classification with re-engagement tracking
- Experiment results: JSON flag parsing with 24h exposure exclusion rule

## Models
| Model | Grain | Upstream |
|-------|-------|----------|
| `int_engagement_states` | user_id x snapshot_week_start | int_events_normalized + int_identity_stitched |
| `int_experiment_results` | user_id x experiment_id | int_events_normalized + int_identity_stitched |

## Test plan
- [ ] `dbt parse` passes
- [ ] SQLFluff lint clean
- [ ] `dbt build` passes against BQ
- [ ] One row per user per week in engagement states
- [ ] accepted_values: pre_active, active, dormant, disengaged
- [ ] exposure_duration_hours >= 24 on all experiment result rows

Depends on: #34
Partial: #19