### PR TITLE
fix: CI test failures, restore lost YAML entries, doc block compliance

### DIFF
--- a/docs/columns.md
+++ b/docs/columns.md
@@ -361,3 +361,251 @@ Whether the invoice has been paid.
 {% docs col_net_amount %}
 Invoice amount minus refund amount.
 {% enddocs %}
+
+---
+
+## MRR movement columns
+
+{% docs col_movement_date %}
+Date of the MRR movement event.
+{% enddocs %}
+
+{% docs col_movement_type %}
+Category of MRR change (new, expansion, contraction, churn, reactivation).
+{% enddocs %}
+
+{% docs col_mrr_before %}
+MRR amount before this movement.
+{% enddocs %}
+
+{% docs col_mrr_after %}
+MRR amount after this movement.
+{% enddocs %}
+
+{% docs col_mrr_delta %}
+Change in MRR (mrr_after minus mrr_before).
+{% enddocs %}
+
+---
+
+## Attribution columns
+
+{% docs col_first_touch_channel %}
+Channel of the first touchpoint within 30 days of activation.
+{% enddocs %}
+
+{% docs col_first_touch_source %}
+UTM source of the first touchpoint. Null for organic users.
+{% enddocs %}
+
+{% docs col_first_touch_medium %}
+UTM medium of the first touchpoint. Null for organic users.
+{% enddocs %}
+
+{% docs col_first_touch_campaign %}
+UTM campaign of the first touchpoint. Null for organic users.
+{% enddocs %}
+
+{% docs col_first_touch_at %}
+Timestamp of the first touchpoint.
+{% enddocs %}
+
+{% docs col_last_touch_channel %}
+Channel of the last touchpoint before activation.
+{% enddocs %}
+
+{% docs col_last_touch_source %}
+UTM source of the last touchpoint. Null for organic users.
+{% enddocs %}
+
+{% docs col_last_touch_medium %}
+UTM medium of the last touchpoint. Null for organic users.
+{% enddocs %}
+
+{% docs col_last_touch_campaign %}
+UTM campaign of the last touchpoint. Null for organic users.
+{% enddocs %}
+
+{% docs col_last_touch_at %}
+Timestamp of the last touchpoint before activation.
+{% enddocs %}
+
+{% docs col_activation_at %}
+Timestamp of the user's first activation event.
+{% enddocs %}
+
+---
+
+## Checkout conversion columns
+
+{% docs col_checkout_event_id %}
+Event ID of the checkout_start event.
+{% enddocs %}
+
+{% docs col_checkout_at %}
+Timestamp of the checkout_start event.
+{% enddocs %}
+
+{% docs col_subscription_at %}
+Timestamp of the matched subscription_start. Null if not converted.
+{% enddocs %}
+
+{% docs col_converted %}
+Whether the checkout led to a subscription within 30 days, or whether a
+user activated after experiment exposure.
+{% enddocs %}
+
+{% docs col_time_to_conversion_days %}
+Days between checkout and subscription. Null if not converted.
+{% enddocs %}
+
+---
+
+## Account health columns
+
+{% docs col_health_score %}
+Composite weighted health score bounded [0, 100]. Activity 40%, billing
+30%, support 30%.
+{% enddocs %}
+
+{% docs col_activity_score %}
+Activity component of health score (40% weight). Based on session count
+in trailing window.
+{% enddocs %}
+
+{% docs col_billing_score %}
+Billing component of health score (30% weight). Based on subscription
+status and recency.
+{% enddocs %}
+
+{% docs col_support_score %}
+Support component of health score (30% weight). Based on ticket volume
+and CSAT scores.
+{% enddocs %}
+
+{% docs col_calculated_at %}
+Timestamp when the health score was calculated.
+{% enddocs %}
+
+{% docs col_trailing_window_days %}
+Number of trailing days used for the score calculation.
+{% enddocs %}
+
+---
+
+## Engagement columns
+
+{% docs col_snapshot_week_start %}
+Monday start date of the snapshot week.
+{% enddocs %}
+
+{% docs col_engagement_state %}
+Weekly engagement classification: pre_active (before activation), active
+(activity within 14d), dormant (14-42d), disengaged (42d+).
+{% enddocs %}
+
+{% docs col_is_re_engaged %}
+Whether the user transitioned from dormant or disengaged to active this
+week.
+{% enddocs %}
+
+{% docs col_days_since_last_activity %}
+Calendar days since the user's last activity as of snapshot week.
+{% enddocs %}
+
+{% docs col_last_activity_at %}
+Timestamp of the user's most recent activity before snapshot week.
+{% enddocs %}
+
+---
+
+## Experiment columns
+
+{% docs col_experiment_id %}
+Experiment identifier from experiment_flags JSON.
+{% enddocs %}
+
+{% docs col_variant %}
+Experiment variant assigned to the user.
+{% enddocs %}
+
+{% docs col_first_exposure_at %}
+Timestamp of the user's first exposure to the experiment.
+{% enddocs %}
+
+{% docs col_conversion_at %}
+Timestamp of activation after experiment exposure. Null if not converted.
+{% enddocs %}
+
+{% docs col_exposure_duration_hours %}
+Hours between first and last exposure event. Only rows with 24+ hours are
+included (24h exclusion rule).
+{% enddocs %}
+
+---
+
+## Identity columns
+
+{% docs col_stitch_source %}
+How the identity stitch was determined (last_touch or historical).
+{% enddocs %}
+
+## Session columns
+
+{% docs col_session_id %}
+Deterministic hash of anon_id and first event ID within the session.
+{% enddocs %}
+
+{% docs col_stitched_user_id %}
+Authenticated user ID resolved via identity stitching. Null for anonymous
+sessions.
+{% enddocs %}
+
+{% docs col_session_start_at %}
+Timestamp of the first event in the session.
+{% enddocs %}
+
+{% docs col_session_end_at %}
+Timestamp of the last event in the session.
+{% enddocs %}
+
+{% docs col_session_duration_seconds %}
+Duration of session in seconds (end minus start).
+{% enddocs %}
+
+{% docs col_event_count %}
+Number of events in the session.
+{% enddocs %}
+
+{% docs col_page_view_count %}
+Number of page_view events in the session.
+{% enddocs %}
+
+{% docs col_session_date %}
+Date of the session start.
+{% enddocs %}
+
+---
+
+## Funnel columns
+
+{% docs col_stage %}
+Funnel stage name (page_view, signup, activation, feature_use,
+checkout_start).
+{% enddocs %}
+
+{% docs col_stage_reached_at %}
+Timestamp when this funnel stage was first reached.
+{% enddocs %}
+
+{% docs col_is_current_stage %}
+Whether this is the user's highest funnel stage.
+{% enddocs %}
+
+---
+
+## Membership columns
+
+{% docs col_membership_duration_days %}
+Duration of account membership in calendar days.
+{% enddocs %}

--- a/models/intermediate/billing/_models.yml
+++ b/models/intermediate/billing/_models.yml
@@ -107,12 +107,12 @@ models:
           - not_null
 
       - name: movement_date
-        description: Date of the MRR movement.
+        description: '{{ doc("col_movement_date") }}'
         tests:
           - not_null
 
       - name: movement_type
-        description: Category of MRR change.
+        description: '{{ doc("col_movement_type") }}'
         tests:
           - not_null
           - accepted_values:
@@ -124,16 +124,16 @@ models:
                 - reactivation
 
       - name: mrr_before
-        description: MRR amount before this movement.
+        description: '{{ doc("col_mrr_before") }}'
         tests:
           - not_null
 
       - name: mrr_after
-        description: MRR amount after this movement.
+        description: '{{ doc("col_mrr_after") }}'
         tests:
           - not_null
 
       - name: mrr_delta
-        description: Change in MRR (mrr_after - mrr_before).
+        description: '{{ doc("col_mrr_delta") }}'
         tests:
           - not_null

--- a/models/intermediate/cross_domain/_models.yml
+++ b/models/intermediate/cross_domain/_models.yml
@@ -207,47 +207,47 @@ models:
           - not_null
 
       - name: first_touch_channel
-        description: Channel of the first touchpoint within 30 days of activation.
+        description: '{{ doc("col_first_touch_channel") }}'
         tests:
           - not_null:
               config:
                 where: "activation_at is not null"
 
       - name: first_touch_source
-        description: UTM source of the first touchpoint. Null for organic users.
+        description: '{{ doc("col_first_touch_source") }}'
 
       - name: first_touch_medium
-        description: UTM medium of the first touchpoint. Null for organic users.
+        description: '{{ doc("col_first_touch_medium") }}'
 
       - name: first_touch_campaign
-        description: UTM campaign of the first touchpoint. Null for organic users.
+        description: '{{ doc("col_first_touch_campaign") }}'
 
       - name: first_touch_at
-        description: Timestamp of the first touchpoint.
+        description: '{{ doc("col_first_touch_at") }}'
         tests:
           - not_null
 
       - name: last_touch_channel
-        description: Channel of the last touchpoint before activation.
+        description: '{{ doc("col_last_touch_channel") }}'
         tests:
           - not_null
 
       - name: last_touch_source
-        description: UTM source of the last touchpoint. Null for organic users.
+        description: '{{ doc("col_last_touch_source") }}'
 
       - name: last_touch_medium
-        description: UTM medium of the last touchpoint. Null for organic users.
+        description: '{{ doc("col_last_touch_medium") }}'
 
       - name: last_touch_campaign
-        description: UTM campaign of the last touchpoint. Null for organic users.
+        description: '{{ doc("col_last_touch_campaign") }}'
 
       - name: last_touch_at
-        description: Timestamp of the last touchpoint before activation.
+        description: '{{ doc("col_last_touch_at") }}'
         tests:
           - not_null
 
       - name: activation_at
-        description: Timestamp of the user's first activation event.
+        description: '{{ doc("col_activation_at") }}'
         tests:
           - not_null
 
@@ -258,7 +258,7 @@ models:
         - intermediate
     columns:
       - name: checkout_event_id
-        description: Event ID of the checkout_start event.
+        description: '{{ doc("col_checkout_event_id") }}'
         tests:
           - unique
           - not_null
@@ -270,11 +270,9 @@ models:
 
       - name: account_id
         description: '{{ doc("col_account_id") }}'
-        tests:
-          - not_null
 
       - name: checkout_at
-        description: Timestamp of the checkout_start event.
+        description: '{{ doc("col_event_time") }}'
         tests:
           - not_null
 
@@ -282,18 +280,18 @@ models:
         description: '{{ doc("col_target_plan") }}'
 
       - name: subscription_event_id
-        description: Matched subscription_start event ID. Null if not converted.
+        description: '{{ doc("col_subscription_event_id") }}'
 
       - name: subscription_at
-        description: Timestamp of the matched subscription_start. Null if not converted.
+        description: '{{ doc("col_subscription_at") }}'
 
       - name: converted
-        description: Whether the checkout led to a subscription within 30 days.
+        description: '{{ doc("col_converted") }}'
         tests:
           - not_null
 
       - name: time_to_conversion_days
-        description: Days between checkout and subscription. Null if not converted.
+        description: '{{ doc("col_time_to_conversion_days") }}'
         tests:
           - dbt_utils.expression_is_true:
               expression: "<= 30 or time_to_conversion_days is null"
@@ -311,7 +309,7 @@ models:
           - not_null
 
       - name: health_score
-        description: Composite weighted health score bounded [0, 100].
+        description: '{{ doc("col_health_score") }}'
         tests:
           - not_null
           - dbt_expectations.expect_column_values_to_be_between:
@@ -319,7 +317,7 @@ models:
               max_value: 100
 
       - name: activity_score
-        description: Activity component (40% weight). Based on session count.
+        description: '{{ doc("col_activity_score") }}'
         tests:
           - not_null
           - dbt_expectations.expect_column_values_to_be_between:
@@ -327,7 +325,7 @@ models:
               max_value: 100
 
       - name: billing_score
-        description: Billing component (30% weight). Based on subscription status.
+        description: '{{ doc("col_billing_score") }}'
         tests:
           - not_null
           - dbt_expectations.expect_column_values_to_be_between:
@@ -335,7 +333,7 @@ models:
               max_value: 100
 
       - name: support_score
-        description: Support component (30% weight). Based on ticket volume and CSAT.
+        description: '{{ doc("col_support_score") }}'
         tests:
           - not_null
           - dbt_expectations.expect_column_values_to_be_between:
@@ -343,11 +341,11 @@ models:
               max_value: 100
 
       - name: calculated_at
-        description: Timestamp when the health score was calculated.
+        description: '{{ doc("col_calculated_at") }}'
         tests:
           - not_null
 
       - name: trailing_window_days
-        description: Number of trailing days used for the score calculation (28).
+        description: '{{ doc("col_trailing_window_days") }}'
         tests:
           - not_null

--- a/models/intermediate/engagement/_models.yml
+++ b/models/intermediate/engagement/_models.yml
@@ -18,14 +18,12 @@ models:
           - not_null
 
       - name: snapshot_week_start
-        description: Monday start date of the snapshot week.
+        description: '{{ doc("col_snapshot_week_start") }}'
         tests:
           - not_null
 
       - name: engagement_state
-        description: >
-          Weekly engagement classification: pre_active (before activation),
-          active (activity within 14d), dormant (14-42d), disengaged (42d+).
+        description: '{{ doc("col_engagement_state") }}'
         tests:
           - not_null
           - accepted_values:
@@ -36,17 +34,15 @@ models:
                 - disengaged
 
       - name: is_re_engaged
-        description: >
-          Whether the user transitioned from dormant or disengaged to active
-          this week.
+        description: '{{ doc("col_is_re_engaged") }}'
         tests:
           - not_null
 
       - name: days_since_last_activity
-        description: Calendar days since the user's last activity as of snapshot week.
+        description: '{{ doc("col_days_since_last_activity") }}'
 
       - name: last_activity_at
-        description: Timestamp of the user's most recent activity before snapshot week.
+        description: '{{ doc("col_last_activity_at") }}'
 
   - name: int_experiment_results
     description: '{{ doc("int_experiment_results") }}'
@@ -65,32 +61,30 @@ models:
           - not_null
 
       - name: experiment_id
-        description: Experiment identifier from experiment_flags JSON.
+        description: '{{ doc("col_experiment_id") }}'
         tests:
           - not_null
 
       - name: variant
-        description: Experiment variant assigned to the user.
+        description: '{{ doc("col_variant") }}'
         tests:
           - not_null
 
       - name: first_exposure_at
-        description: Timestamp of the user's first exposure to the experiment.
+        description: '{{ doc("col_first_exposure_at") }}'
         tests:
           - not_null
 
       - name: converted
-        description: Whether the user activated after experiment exposure.
+        description: '{{ doc("col_converted") }}'
         tests:
           - not_null
 
       - name: conversion_at
-        description: Timestamp of activation after exposure. Null if not converted.
+        description: '{{ doc("col_conversion_at") }}'
 
       - name: exposure_duration_hours
-        description: >
-          Hours between first and last exposure event. Only rows with
-          exposure_duration_hours >= 24 are included (24h exclusion rule).
+        description: '{{ doc("col_exposure_duration_hours") }}'
         tests:
           - not_null
           - dbt_expectations.expect_column_values_to_be_between:

--- a/models/intermediate/engagement/int_engagement_states.sql
+++ b/models/intermediate/engagement/int_engagement_states.sql
@@ -152,8 +152,11 @@ select
     user_id,
     snapshot_week_start,
     engagement_state,
-    previous_state in ('dormant', 'disengaged')
-    and engagement_state = 'active' as is_re_engaged,
+    coalesce(
+        previous_state in ('dormant', 'disengaged')
+        and engagement_state = 'active',
+        false
+    ) as is_re_engaged,
     days_since_last_activity,
     last_activity_at
 from classified

--- a/models/intermediate/product/_models.yml
+++ b/models/intermediate/product/_models.yml
@@ -145,17 +145,15 @@ models:
           - not_null
 
       - name: valid_from
-        description: Start of the identity stitch interval (inclusive).
+        description: '{{ doc("col_valid_from") }}'
         tests:
           - not_null
 
       - name: valid_to
-        description: >
-          End of the identity stitch interval (exclusive). Null means the
-          mapping is current/open-ended.
+        description: '{{ doc("col_valid_to") }}'
 
       - name: stitch_source
-        description: How the stitch was determined (last_touch or historical).
+        description: '{{ doc("col_stitch_source") }}'
         tests:
           - not_null
           - accepted_values:
@@ -189,18 +187,124 @@ models:
         description: '{{ doc("col_member_role") }}'
 
       - name: valid_from
-        description: Timestamp when the user joined the account.
+        description: '{{ doc("col_valid_from") }}'
         tests:
           - not_null
 
       - name: valid_to
-        description: >
-          Timestamp when the user was removed from the account.
-          Null means the user is still a member.
+        description: '{{ doc("col_valid_to") }}'
 
       - name: membership_duration_days
-        description: Duration of membership in calendar days.
+        description: '{{ doc("col_membership_duration_days") }}'
         tests:
           - not_null
           - dbt_expectations.expect_column_values_to_be_between:
               min_value: 0
+
+  - name: int_sessions
+    description: '{{ doc("int_sessions") }}'
+    config:
+      tags:
+        - intermediate
+    columns:
+      - name: session_id
+        description: '{{ doc("col_session_id") }}'
+        tests:
+          - unique
+          - not_null
+
+      - name: anon_id
+        description: '{{ doc("col_anon_id") }}'
+        tests:
+          - not_null
+
+      - name: stitched_user_id
+        description: '{{ doc("col_stitched_user_id") }}'
+
+      - name: session_start_at
+        description: '{{ doc("col_session_start_at") }}'
+        tests:
+          - not_null
+
+      - name: session_end_at
+        description: '{{ doc("col_session_end_at") }}'
+        tests:
+          - not_null
+
+      - name: session_duration_seconds
+        description: '{{ doc("col_session_duration_seconds") }}'
+        tests:
+          - not_null
+          - dbt_expectations.expect_column_values_to_be_between:
+              min_value: 0
+
+      - name: event_count
+        description: '{{ doc("col_event_count") }}'
+        tests:
+          - not_null
+          - dbt_expectations.expect_column_values_to_be_between:
+              min_value: 1
+
+      - name: page_view_count
+        description: '{{ doc("col_page_view_count") }}'
+
+      - name: utm_source
+        description: '{{ doc("col_utm_source") }}'
+
+      - name: utm_medium
+        description: '{{ doc("col_utm_medium") }}'
+
+      - name: utm_campaign
+        description: '{{ doc("col_utm_campaign") }}'
+
+      - name: platform
+        description: '{{ doc("col_platform") }}'
+
+      - name: device_type
+        description: '{{ doc("col_device_type") }}'
+
+      - name: browser
+        description: '{{ doc("col_browser") }}'
+
+      - name: session_date
+        description: '{{ doc("col_session_date") }}'
+        tests:
+          - not_null
+
+  - name: int_funnel_staged
+    description: '{{ doc("int_funnel_staged") }}'
+    config:
+      tags:
+        - intermediate
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          combination_of_columns:
+            - user_id
+            - stage
+    columns:
+      - name: user_id
+        description: '{{ doc("col_user_id") }}'
+        tests:
+          - not_null
+
+      - name: stage
+        description: '{{ doc("col_stage") }}'
+        tests:
+          - not_null
+          - accepted_values:
+              values:
+                - page_view
+                - signup
+                - activation
+                - feature_use
+                - checkout_start
+
+      - name: stage_reached_at
+        description: '{{ doc("col_stage_reached_at") }}'
+        tests:
+          - not_null
+
+      - name: is_current_stage
+        description: '{{ doc("col_is_current_stage") }}'
+        tests:
+          - not_null


### PR DESCRIPTION
## Summary
- Fix 2 CI test failures from PR #33-37 merge
- Restore `int_sessions` and `int_funnel_staged` YAML entries lost in PR #37 squash merge
- Replace all inline descriptions with `{{ doc() }}` refs per doc-block-convention

## Fixes
1. **`not_null_int_engagement_states_is_re_engaged`**: COALESCE LAG result to false for first week per user
2. **`not_null_int_checkout_conversion_account_id`**: Remove not_null — anonymous checkout events have NULL account_id
3. **Lost YAML entries**: `int_sessions` and `int_funnel_staged` schemas (PK tests, column tests) were dropped by PR #37 squash merge
4. **Inline descriptions**: ~50 inline strings replaced with `{{ doc() }}` refs, ~50 new doc blocks added to `docs/columns.md`

## Test plan
- [ ] `dbt parse` passes
- [ ] CI passes (276+ PASS, 0 ERROR)
- [ ] `grep -v 'doc(' models/intermediate/*/_models.yml | grep 'description:'` returns empty