### PR TITLE
fix: isolate CI datasets per-PR to prevent concurrent write conflicts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,7 @@
 # ============================================================
 # AUTOMATION: CI
 # WHAT IT DOES: Lints SQL, validates naming, builds + tests all models
-# WHAT IT MODIFIES: Creates/refreshes CI BQ datasets (analytics_ci_*)
+# WHAT IT MODIFIES: Creates/refreshes per-PR CI BQ datasets (analytics_ci_{pr_number}_*)
 # AUTO-COMMITS: No
 # HOW TO DISABLE: Delete this file
 # ============================================================
@@ -48,6 +48,9 @@ jobs:
     name: Build & Validate
     needs: lint
     runs-on: ubuntu-latest
+    env:
+      GCP_PROJECT_ID: ${{ secrets.GCP_PROJECT_ID }}
+      PR_NUMBER: ${{ github.event.pull_request.number || github.run_id }}
     steps:
       - uses: actions/checkout@v4
 
@@ -82,13 +85,9 @@ jobs:
 
       - name: Build all models and run tests
         run: dbt build --target ci --full-refresh
-        env:
-          GCP_PROJECT_ID: ${{ secrets.GCP_PROJECT_ID }}
 
       - name: Run dbt-project-evaluator
         run: dbt build --select package:dbt_project_evaluator --target ci
-        env:
-          GCP_PROJECT_ID: ${{ secrets.GCP_PROJECT_ID }}
 
       - name: Upload manifest (push to main only)
         if: github.event_name == 'push' && github.ref == 'refs/heads/main'
@@ -97,3 +96,20 @@ jobs:
           name: dbt-manifest
           path: target/manifest.json
           retention-days: 90
+
+      # Non-PR runs use run_id as dataset namespace — clean up after ourselves
+      # since pr-teardown.yml only fires on pull_request closed events.
+      - name: Set up Cloud SDK
+        if: always() && github.event_name != 'pull_request'
+        uses: google-github-actions/setup-gcloud@v2
+
+      - name: Drop ephemeral CI datasets
+        if: always() && github.event_name != 'pull_request'
+        run: |
+          for dataset in \
+            "analytics_ci_${PR_NUMBER}" \
+            "analytics_ci_${PR_NUMBER}_staging" \
+            "analytics_ci_${PR_NUMBER}_intermediate" \
+            "analytics_ci_${PR_NUMBER}_marts"; do
+            bq rm -r -f --project_id="${GCP_PROJECT_ID}" "${dataset}" || true
+          done

--- a/.github/workflows/pr-teardown.yml
+++ b/.github/workflows/pr-teardown.yml
@@ -1,7 +1,7 @@
 # ============================================================
 # AUTOMATION: PR Teardown
-# WHAT IT DOES: Drops CI-created BQ datasets when PR closes
-# WHAT IT MODIFIES: BigQuery datasets (analytics_ci_*)
+# WHAT IT DOES: Drops per-PR CI-created BQ datasets when PR closes
+# WHAT IT MODIFIES: BigQuery datasets (analytics_ci_{pr_number}_*)
 # AUTO-COMMITS: No
 # HOW TO DISABLE: Delete this file
 # ============================================================
@@ -31,10 +31,18 @@ jobs:
       - name: Set up Cloud SDK
         uses: google-github-actions/setup-gcloud@v2
 
-      - name: Drop CI datasets
+      # Dataset list must stay in sync with dbt_project.yml +schema values
+      # (staging, intermediate, marts) plus the base dataset (evaluator tables).
+      - name: Drop CI datasets for this PR
+        env:
+          PR_NUMBER: ${{ github.event.pull_request.number }}
         run: |
-          for dataset in analytics_ci_staging analytics_ci_intermediate analytics_ci_marts; do
-            echo "Dropping $dataset (if exists)..."
-            bq rm -r -f --project_id="${GCP_PROJECT_ID}" "${dataset}" 2>/dev/null || true
+          for dataset in \
+            "analytics_ci_${PR_NUMBER}" \
+            "analytics_ci_${PR_NUMBER}_staging" \
+            "analytics_ci_${PR_NUMBER}_intermediate" \
+            "analytics_ci_${PR_NUMBER}_marts"; do
+            echo "Dropping ${dataset} (if exists)..."
+            bq rm -r -f --project_id="${GCP_PROJECT_ID}" "${dataset}" || true
           done
-          echo "CI dataset cleanup complete."
+          echo "CI dataset cleanup complete for PR #${PR_NUMBER}."

--- a/profiles.yml.example
+++ b/profiles.yml.example
@@ -23,6 +23,6 @@ b2b_saas_dbt:
       type: bigquery
       method: oauth
       project: "{{ env_var('GCP_PROJECT_ID') }}"
-      dataset: analytics_ci
+      dataset: "analytics_ci_{{ env_var('PR_NUMBER', 'local') }}"
       location: EU
       threads: 4


### PR DESCRIPTION
## Summary

CI was failing with two concurrent-access issues:
- `Dataset ***:analytics_ci_staging was not found in location EU` — PR teardowns deleted shared datasets mid-build when PRs merged rapidly
- `Could not serialize access to table ***:analytics_ci.base_node_relationships due to concurrent update` — dbt-project-evaluator hit BQ serialization errors when PR CI and main CI wrote to the same tables simultaneously

Root cause: all CI runs shared a single `analytics_ci` dataset namespace with no isolation.

## Changes

- **profiles.yml.example**: CI dataset now includes `PR_NUMBER` env var (`analytics_ci_{PR_NUMBER}`), defaults to `local` for dev
- **ci.yml**: Hoist `GCP_PROJECT_ID` and `PR_NUMBER` to job-level env (eliminates duplication), fall back to `github.run_id` for non-PR runs, add self-cleanup step for ephemeral datasets
- **pr-teardown.yml**: Scope teardown to the closing PR's datasets only (base + staging/intermediate/marts), remove stderr suppression, add sync comment

## Dataset namespace mapping

| Trigger | PR_NUMBER value | Example datasets |
|---------|----------------|------------------|
| PR #42 | `42` | `analytics_ci_42_staging`, `analytics_ci_42_intermediate`, ... |
| Push to main | `{run_id}` | `analytics_ci_23465851098_staging`, ... |
| Manual dispatch | `{run_id}` | `analytics_ci_23465851098_staging`, ... |
| Local dev | `local` | `analytics_ci_local_staging`, ... |

## Test plan

- [ ] Open a second PR simultaneously — verify both CI runs pass without dataset conflicts
- [ ] Merge a PR — verify teardown drops only that PR's datasets
- [ ] Push to main — verify self-cleanup step removes ephemeral datasets
- [ ] Run `workflow_dispatch` — verify unique run_id namespace and cleanup