### PR TITLE
chore: tiered instruction system with review docs, skills, and lint enforcement

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -47,6 +47,12 @@ repos:
         entry: scripts/secret-scan.sh
         stages: [pre-commit]
 
+      - id: lint-doc-blocks
+        name: lint doc blocks
+        language: script
+        entry: scripts/lint-doc-blocks.sh
+        stages: [pre-commit]
+
       - id: tdd-gate
         name: tdd gate
         language: script

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,7 +17,7 @@ Five source domains: product events, billing subscriptions, billing invoices, ma
 
 ## Hard Rules
 - No `select *` — explicit column lists everywhere
-- `{{ doc() }}` for any field description reused across 2+ models
+- No inline descriptions — every description must use `{{ doc() }}` blocks
 - Contracts required on all staging models and marts `fct_`, `dim_`, `bridge_` models. Optional on `agg_`, `rpt_`, `mart_`
 - No custom governance macros — use dbt-project-evaluator
 - Column naming consistency: same concept = same column name across all models
@@ -27,7 +27,7 @@ Five source domains: product events, billing subscriptions, billing invoices, ma
 - Lowercase keywords, trailing commas, 4-space indent
 - CTEs over subqueries
 - Prefer `group by all` over explicit column ordinals
-- Use `union all by name` for multi-source unions
+- Use `union all` with explicit matching column lists for multi-source unions
 
 ## File Organization
 - Models organized into subdirectories within layers (by source, domain, or business area)
@@ -39,6 +39,14 @@ Five source domains: product events, billing subscriptions, billing invoices, ma
 - Dev builds: `dbt build --exclude package:dbt_project_evaluator`
 - Evaluator runs in CI only (or on demand: `dbt build --select package:dbt_project_evaluator`)
 
+## Documentation
+- Doc block convention: `docs/doc-block-convention.md`
+- Inline descriptions banned — enforced by `scripts/lint-doc-blocks.sh` (pre-commit hook)
+
+## Review
+- PR checklist (layer-specific): `docs/review/pr-checklist.md`
+- Common mistakes and anti-patterns: `docs/review/common-mistakes.md`
+
 ## Git
 - Never commit directly to main — feature branch + PR
 - Conventional commits: feat:, fix:, docs:, test:, refactor:, chore:
@@ -46,4 +54,11 @@ Five source domains: product events, billing subscriptions, billing invoices, ma
 
 ## Layer Details
 Each model directory has its own CLAUDE.md with layer-specific rules.
-Full documentation in `docs/layers/`.
+Full layer contract in `docs/layers/`.
+
+## Skills
+Workflow instructions in `docs/skills/`. Read the relevant file before executing.
+- `dbt-validate` — lint + naming + doc blocks + dbt build
+- `dbt-pr-review` — structured PR review with audit pass
+- `dbt-scaffold` — generate model + YAML + test stubs
+- `dbt-audit` — deep compliance audit (test coverage, layer compliance, docs)

--- a/docs/doc-block-convention.md
+++ b/docs/doc-block-convention.md
@@ -1,5 +1,23 @@
 # Doc Block Convention
 
+## No Inline Descriptions
+
+**Every column and model description must use `{{ doc() }}` blocks. No exceptions.**
+
+```yaml
+# BAD — inline string
+columns:
+  - name: user_id
+    description: "The unique identifier for a user"
+
+# GOOD — doc block reference
+columns:
+  - name: user_id
+    description: "{{ doc('col_user_id') }}"
+```
+
+Enforced by `scripts/lint-doc-blocks.sh` (pre-commit hook) and CI.
+
 ## Naming Patterns
 
 | Scope | Pattern | Example |

--- a/docs/review/common-mistakes.md
+++ b/docs/review/common-mistakes.md
@@ -1,0 +1,54 @@
+# Common Mistakes
+
+Anti-patterns to catch during review and audit. Ordered by frequency.
+
+## Documentation
+
+1. **Inline descriptions in _models.yml** — Every description must use `{{ doc() }}` blocks. Enforced by `scripts/lint-doc-blocks.sh`.
+2. **Duplicate doc blocks** — Same column described twice with different wording. One canonical block per concept.
+3. **Missing doc blocks for new columns** — Column added to model but no `col_` block created in `docs/columns.md`.
+4. **Wrong doc block scope** — Using `col_status` when the column is domain-specific (should be `col_ticket_status`).
+
+## Layer Violations
+
+5. **`source()` in intermediate or marts** — Intermediate must use `ref()` to staging. Marts must `ref()` intermediate.
+6. **`ref()` staging from marts** — Marts must go through intermediate. If the staging model is needed directly, create a thin `int_*_prep` model.
+7. **Business logic in staging** — No joins, aggregations, window functions, or derived columns in staging. Only 1:1 shaping.
+8. **`contract.enforced` on intermediate** — Intermediate is internal; contracts not needed. Only staging + fct_/dim_/bridge_ marts.
+9. **Wrong materialization** — Staging = view. Intermediate = view (exception: int_events_normalized is incremental). Marts = table.
+
+## Testing
+
+10. **Missing PK tests** — Every model needs `not_null` + `unique` on its primary key. No exceptions.
+11. **`accepted_values` on BigQuery BOOL** — Doesn't work. BigQuery BOOL is native; use `contract.enforced` with `data_type: boolean` instead.
+12. **Missing FK relationship tests** — Every FK column should have a `relationships` test. Prefer testing in staging (cheaper).
+13. **Missing `accepted_values` on categoricals** — Every CASE WHEN output and status/type/category column needs `accepted_values`.
+14. **Wrong severity** — PK violations and contract enforcement must be `error`. Data quality alerts and large-table relationship tests should be `warn`.
+
+## Naming
+
+15. **Wrong prefix** — staging: `stg_`, intermediate: `int_`, marts: `fct_`/`dim_`/`bridge_`/`agg_`/`rpt_`/`mart_`.
+16. **Single underscore in staging** — Must be double: `stg_{source}__{entity}`.
+17. **Column name drift** — Same concept must use same column name everywhere.
+
+## Marts-Specific
+
+18. **Missing `meta`** — All marts models require: owner, pii (boolean), sla, tier (1-5).
+19. **Missing contracts on fct_/dim_/bridge_** — These model types always need `contract.enforced: true`.
+20. **Non-conformed dimension keys** — Fact tables must use shared dim keys, not local FK columns.
+
+## Locked Business Logic Violations
+
+These decisions are frozen. Any model that contradicts them is wrong.
+
+21. **Identity stitching** — Must use 90-day stitch window, half-open intervals `[valid_from, valid_to)`, deterministic last-touch join. Join: `LEFT JOIN ... ON anon_id AND event_time >= valid_from AND event_time < valid_to`.
+
+22. **Sessionization** — 30-minute inactivity timeout. Sessions span midnight. Session ID = `hash(anon_id + first_event_id)` — immutable, no stitched identity in the key.
+
+23. **Engagement states** — 4 mutually exclusive states: `pre_active`, `active`, `dormant`, `disengaged`. `is_re_engaged` is a boolean flag, NOT a state. Thresholds: active (14d), dormant (14-42d), disengaged (42d+).
+
+24. **Attribution** — User-level only (account-level in dim_accounts only). First-touch + last-touch, 30-day window before activation. Conversion event = `activation` event_type.
+
+25. **Retention** — Pre-computed in dbt as `fct_retention_cohorts`. Activation-week cohorts, `cohort_week_start_date` (DATE, always Monday). `is_period_complete` guard with 7-day buffer.
+
+26. **Canonical activation** — `activation` event_type is THE definition everywhere: funnel, attribution, retention, engagement.

--- a/docs/review/pr-checklist.md
+++ b/docs/review/pr-checklist.md
@@ -1,0 +1,69 @@
+# PR Review Checklist
+
+Apply the layer-specific section based on which files changed.
+
+## All Layers
+
+- [ ] No inline descriptions — every description uses `{{ doc() }}` blocks
+- [ ] No `select *` — explicit column lists
+- [ ] SQLFluff clean (lowercase keywords, trailing commas, 4-space indent)
+- [ ] CTEs over subqueries
+- [ ] Column names match existing conventions (same concept = same name across models)
+- [ ] PK tested: `not_null` + `unique` on every model
+- [ ] Conventional commit message
+- [ ] Doc blocks created/updated in `docs/columns.md` for new columns
+
+## Staging
+
+- [ ] Model name: `stg_{source}__{entity}` (double underscore)
+- [ ] `contract.enforced: true` in _models.yml
+- [ ] Only `source()` references — no `ref()`
+- [ ] No joins, aggregations, window functions, or derived columns
+- [ ] Column types cast to canonical (TIMESTAMP, DATE, STRING, INT64, NUMERIC)
+- [ ] Columns renamed to snake_case, no abbreviations
+- [ ] JSON shredding to flat columns where appropriate
+- [ ] `_sources.yml` present in subdirectory
+- [ ] FK columns tested with `relationships`
+- [ ] Enum columns tested with `accepted_values`
+- [ ] Boolean columns: `contract.enforced` with `data_type: boolean` (NOT `accepted_values`)
+
+## Intermediate
+
+- [ ] Model name: `int_{domain}_{concept}` (optional `_prep` or `_unioned` suffix)
+- [ ] Only `ref()` — no `source()` references
+- [ ] No `contract.enforced` (intermediate is internal)
+- [ ] Materialized as view (exception: `int_events_normalized` is incremental)
+- [ ] Correct subdirectory: product/, billing/, engagement/, or cross_domain/
+- [ ] New derived columns tested (CASE WHEN outputs, aggregations, window functions)
+- [ ] Business logic consistent with locked decisions (see common-mistakes.md)
+- [ ] Skip tests on passthrough columns already tested in staging
+
+## Marts
+
+- [ ] Model name: `fct_`, `dim_`, `bridge_`, `agg_`, `rpt_`, or `mart_` prefix
+- [ ] `contract.enforced: true` on `fct_`, `dim_`, `bridge_` models
+- [ ] `meta` present: owner, pii (boolean), sla, tier (1-5)
+- [ ] Materialized as table
+- [ ] `ref()` intermediate models only for `fct_`/`dim_`/`bridge_` — never staging, never source
+- [ ] `agg_`/`rpt_`/`mart_` may also `ref()` other marts models
+- [ ] Conformed dimension keys: FK columns reference shared dim keys
+- [ ] Role-playing FKs use suffixed keys (e.g., `session_date_key`, `acquisition_date_key`)
+- [ ] FK columns tested with `relationships` to conformed dimensions
+- [ ] Re-test critical business fields even if tested upstream (safety net)
+- [ ] Correct subdirectory: core/, product/, billing/, marketing/, or support/
+
+## Tests
+
+- [ ] Singular test name: `{category}_{model}_{invariant}.sql`
+- [ ] Test in correct subdirectory: invariants/, reconciliation/, fanout/, or contracts/
+- [ ] `config: severity:` set (error for critical, warn for data quality)
+- [ ] Description present in config block
+- [ ] No reinventing the wheel — check dbt_utils/dbt_expectations before custom SQL
+- [ ] `config: where:` used on large table tests for performance
+
+## Cross-Model
+
+- [ ] No column name drift (same business concept uses same name everywhere)
+- [ ] FK naming consistent across layers
+- [ ] No orphaned doc blocks (blocks added but no model references them)
+- [ ] Models in _models.yml match actual SQL files (no phantom entries)

--- a/docs/skills/dbt-audit.md
+++ b/docs/skills/dbt-audit.md
@@ -1,0 +1,61 @@
+# dbt-audit
+
+Deep compliance audit across the entire project. Do ALL steps automatically without asking:
+
+1. **Detect project** — Find `dbt_project.yml` in CWD or parents. Abort if not a dbt project.
+
+2. **Load rules:**
+   - Read `docs/review/common-mistakes.md`
+   - Read `docs/review/pr-checklist.md`
+   - Read each layer CLAUDE.md
+   - Read `tests/CLAUDE.md`
+
+3. **Run audit categories:**
+
+   a. **Test coverage** — Parse all `_models.yml` files:
+      - Flag models without PK tests (`not_null` + `unique`)
+      - Flag FK columns without `relationships` tests
+      - Flag categorical columns without `accepted_values`
+      - Flag boolean columns using `accepted_values` instead of contract enforcement
+      - Flag numeric columns missing range checks where applicable
+
+   b. **Layer compliance** — Check every model:
+      - Staging models use only `source()`, never `ref()`
+      - Intermediate models use only `ref()`, never `source()`
+      - Marts models ref intermediate only (fct_/dim_/bridge_), not staging
+      - Materialization matches layer rules (staging=view, intermediate=view, marts=table)
+      - `contract.enforced` set where required (staging + fct_/dim_/bridge_ marts)
+
+   c. **Documentation completeness**:
+      - Run `scripts/lint-doc-blocks.sh` for inline description violations
+      - Scan for columns in _models.yml without any description
+      - Scan `docs/columns.md` for doc blocks not referenced by any model
+      - Check model descriptions exist and use `{{ doc() }}` blocks
+
+   d. **Naming compliance**:
+      - Run `scripts/lint-model-names.sh`
+      - Check column naming consistency across layers (same concept = same name)
+
+   e. **Meta compliance** (marts only):
+      - Check all marts models for required meta fields: owner, pii, sla, tier
+
+4. **Present scored report:**
+```
+## dbt Audit Report
+
+| Category           | Status | Issues |
+|--------------------|--------|--------|
+| Test coverage      | PASS/WARN/FAIL | N |
+| Layer compliance   | PASS/WARN/FAIL | N |
+| Documentation      | PASS/WARN/FAIL | N |
+| Naming             | PASS/WARN/FAIL | N |
+| Meta compliance    | PASS/WARN/FAIL | N |
+
+### Issues by Severity
+#### CRITICAL
+- ...
+#### WARNING
+- ...
+
+### Overall: N/5 categories pass
+```

--- a/docs/skills/dbt-pr-review.md
+++ b/docs/skills/dbt-pr-review.md
@@ -1,0 +1,47 @@
+# dbt-pr-review
+
+Structured PR review with audit pass. Do ALL steps automatically without asking:
+
+1. **Detect project** — Find `dbt_project.yml` in CWD or parents. Abort if not a dbt project.
+
+2. **Gather context:**
+   - Changed files: `git diff main...HEAD --name-only`
+   - Full diff: `git diff main...HEAD`
+   - Classify changes by layer (staging/intermediate/marts/tests/docs/scripts)
+   - Read the changed files
+
+3. **Load review rules:**
+   - Read `docs/review/pr-checklist.md`
+   - Read `docs/review/common-mistakes.md`
+   - Read `docs/doc-block-convention.md`
+   - Read the relevant layer CLAUDE.md for each changed layer
+
+4. **Review pass** (checklist from pr-checklist.md):
+   - Apply layer-specific checklist items to each changed model file
+   - Check _models.yml changes for inline descriptions, missing tests, missing doc blocks
+   - Match against common-mistakes.md anti-patterns
+
+5. **Audit pass** (scoped to changed files only):
+   - **Test coverage**: flag changed models missing PK tests (not_null+unique), FK relationships, accepted_values on categoricals
+   - **Layer compliance**: verify ref() usage, materialization, contract.enforced
+   - **Documentation**: no inline descriptions, doc blocks present for all columns
+   - **Naming**: validate model names against conventions
+   - **Meta**: check marts models for required meta fields (owner, pii, sla, tier)
+   - **Business logic**: verify against locked decisions in common-mistakes.md
+
+6. **Output** — structured findings with severity:
+```
+## PR Review: <branch>
+
+### CRITICAL (must fix before merge)
+- file:line — finding
+
+### WARNING (should fix)
+- file:line — finding
+
+### INFO (optional improvement)
+- file:line — finding
+
+### What's Done Well
+- ...
+```

--- a/docs/skills/dbt-scaffold.md
+++ b/docs/skills/dbt-scaffold.md
@@ -1,0 +1,42 @@
+# dbt-scaffold
+
+Generate a new model with all conventions applied. Do ALL steps automatically without asking:
+
+1. **Parse arguments** — `$ARGUMENTS` format: `<layer> <model_name>` (e.g., `intermediate int_billing_payments_prep`)
+   - If missing, ask for layer and model name
+
+2. **Validate:**
+   - Layer must be staging, intermediate, or marts
+   - Model name must match naming convention for that layer (run through `scripts/lint-model-names.sh` pattern)
+   - Infer subdirectory from model name (e.g., `int_billing_*` → `models/intermediate/billing/`)
+
+3. **Read layer rules:**
+   - Read the layer's CLAUDE.md (e.g., `models/intermediate/CLAUDE.md`)
+   - Read `docs/doc-block-convention.md` for doc block patterns
+
+4. **Generate SQL file** with layer-appropriate template:
+   - **Staging**: `source()` ref, explicit column list, type casting, contract-ready
+   - **Intermediate**: `ref()` to staging/intermediate, CTE structure, business logic placeholder
+   - **Marts**: `ref()` to intermediate, light joins, FK assembly, contract-ready
+
+5. **Update _models.yml** in the target subdirectory:
+   - Add model entry with `{{ doc() }}` description placeholder
+   - Add column entries with `{{ doc() }}` descriptions
+   - Add PK tests: `not_null` + `unique`
+   - For staging: add `contract.enforced: true`
+   - For marts fct_/dim_/bridge_: add `contract.enforced: true` and `meta` block
+
+6. **Create doc block stubs** in `docs/columns.md` for any new columns not already defined
+
+7. **Report** what was created:
+```
+Created:
+  models/<layer>/<subdir>/<model_name>.sql
+  Updated: models/<layer>/<subdir>/_models.yml
+  Updated: docs/columns.md (N new doc blocks)
+
+Next steps:
+  - Implement the SQL logic
+  - Add FK relationship tests
+  - Add accepted_values tests for categorical columns
+```

--- a/docs/skills/dbt-validate.md
+++ b/docs/skills/dbt-validate.md
@@ -1,0 +1,31 @@
+# dbt-validate
+
+Run dbt project validation. Do ALL steps automatically without asking:
+
+1. **Detect project** — Find `dbt_project.yml` in CWD or parents. Abort if not a dbt project.
+
+2. **Parse arguments** — Check `$ARGUMENTS` for flags:
+   - `--fix`: run sqlfluff in fix mode instead of lint
+   - `--quick`: skip dbt build, lint checks only
+
+3. **Run checks sequentially**, collecting pass/fail for each:
+
+   a. **SQL lint** — `sqlfluff lint models/` (or `sqlfluff fix models/` if `--fix`). Report violations.
+
+   b. **Model naming** — `scripts/lint-model-names.sh`. Enforces stg_/int_/fct_/dim_/bridge_/agg_/rpt_/mart_ conventions.
+
+   c. **Doc block lint** — `scripts/lint-doc-blocks.sh`. Catches any inline descriptions in _models.yml (must use `{{ doc() }}` blocks).
+
+   d. **dbt build** (skip if `--quick`) — `dbt build --exclude package:dbt_project_evaluator`. Parses, compiles, runs models, and executes tests.
+
+4. **Present summary:**
+```
+Validation: <project>
+  SQL lint:      PASS/FAIL (N violations)
+  Model naming:  PASS/FAIL
+  Doc blocks:    PASS/FAIL (N inline descriptions)
+  dbt build:     PASS/FAIL (N models, N tests passed, N failed) | SKIPPED
+```
+
+5. **If all pass** — one-line confirmation.
+   **If failures** — list failures with file:line references. Do not attempt to fix unless `--fix` was passed.

--- a/models/intermediate/CLAUDE.md
+++ b/models/intermediate/CLAUDE.md
@@ -9,6 +9,7 @@ All business logic lives here. Dedup, sessionization, identity stitching, attrib
 - Naming: `int_{domain}_{concept}` (suffixes: `_prep` for source-specific prep, `_unioned` for multi-source union)
 - `ref()` staging or other intermediate models only — never `source()`
 - No `contract.enforced` (intermediate is internal)
+- No inline descriptions — all descriptions must use `{{ doc() }}` blocks
 
 ## What Belongs Here
 - Deduplication and normalization

--- a/models/marts/CLAUDE.md
+++ b/models/marts/CLAUDE.md
@@ -18,6 +18,7 @@ Kimball star schema. Consumer-facing facts and dimensions.
 - `agg_`, `rpt_`, `mart_` may also `ref()` other marts models (facts, dimensions)
 - Conformed dimensions: shared dim keys across all facts
 - Role-playing FKs use suffixed keys (e.g., `session_date_key`, `acquisition_date_key`)
+- No inline descriptions — all descriptions must use `{{ doc() }}` blocks
 
 ## What Belongs Here
 - Fact tables at declared grain (one row = one event/snapshot)

--- a/models/staging/CLAUDE.md
+++ b/models/staging/CLAUDE.md
@@ -12,6 +12,7 @@
 - Cast to canonical types (TIMESTAMP, DATE, STRING, INT64, NUMERIC)
 - Rename source columns to snake_case, no abbreviations
 - Column naming consistency: columns referring to the same business concept must use identical names across all staging models
+- No inline descriptions — all descriptions must use `{{ doc() }}` blocks
 
 ## What Belongs Here
 - Column renaming and type casting

--- a/scripts/lint-doc-blocks.sh
+++ b/scripts/lint-doc-blocks.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Enforce: no inline descriptions in _models.yml files.
+# Every description must use {{ doc() }} blocks.
+# See docs/doc-block-convention.md for full convention.
+
+EXIT_CODE=0
+
+while IFS= read -r -d '' file; do
+    # Find description lines that are NOT {{ doc() }} references.
+    # Match: description: "some text" or description: 'some text' or description: some text
+    # Skip: description: "{{ doc(...) }}" and empty/blank descriptions
+    while IFS= read -r line_info; do
+        line_num="${line_info%%:*}"
+        line_content="${line_info#*:}"
+        echo "FAIL: $file:$line_num — inline description found"
+        echo "      $line_content"
+        EXIT_CODE=1
+    done < <(grep -nE '^\s+description:\s' "$file" \
+        | grep -vE '\{\{.*doc\(' \
+        | grep -vE '^\s+description:\s*$' \
+        | grep -vE "^\s+description:\s*['\"]?\s*['\"]?\s*$" \
+        || true)
+done < <(find models -name '_models.yml' -print0 2>/dev/null)
+
+if [[ $EXIT_CODE -eq 0 ]]; then
+    echo "All descriptions use {{ doc() }} blocks."
+fi
+
+exit $EXIT_CODE


### PR DESCRIPTION
## What changed

Added a structured documentation layer for project governance:

- `docs/review/` — PR review checklist (layer-specific) and 26 common anti-patterns including locked business logic decisions
- `docs/skills/` — Workflow docs for validate, pr-review, scaffold, and audit
- `scripts/lint-doc-blocks.sh` — Enforcement script that catches inline descriptions in `_models.yml`
- Inline description ban added to root CLAUDE.md, all layer CLAUDE.md files, and doc-block-convention.md
- Pre-commit hook added for lint-doc-blocks

## Why

Rules were scattered across CLAUDE.md, tests/CLAUDE.md, docs/layers/, and the PR template with no structured review process. Inline descriptions kept leaking back into `_models.yml` files. This change organizes everything into a tiered system with enforcement.

## Checklist
- [x] No new models (docs/scripts only)
- [x] lint-doc-blocks.sh tested against current codebase (passes)
- [x] CLAUDE.md under 65 lines
- [x] No AI fingerprints
- [x] Pre-commit hook added

## Test plan
- `scripts/lint-doc-blocks.sh` — passes on current codebase
- `scripts/lint-model-names.sh` — still passes (unchanged)
- All new files are documentation — no dbt build impact