### PR TITLE
feat: retention cohorts and cross-model FK tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,4 @@ scripts/synthetic_data/
 
 # Local tool config
 .claude/settings.local.json
+.envrc

--- a/docs/columns.md
+++ b/docs/columns.md
@@ -680,6 +680,11 @@ concatenation of account ID and subscription event ID.
 Surrogate key for the invoice fact. farm_fingerprint hash of the invoice ID.
 {% enddocs %}
 
+{% docs col_retention_cohort_key %}
+Surrogate key for the retention cohort fact. farm_fingerprint hash of the
+concatenation of cohort week start date and retention period.
+{% enddocs %}
+
 ---
 
 ## Date dimension columns
@@ -793,6 +798,14 @@ Foreign key to dim_date for the marketing spend date.
 Foreign key to dim_date for the experiment first-exposure date.
 {% enddocs %}
 
+{% docs col_cohort_week_date_key %}
+Foreign key to dim_date for the cohort week start date (always a Monday).
+{% enddocs %}
+
+{% docs col_period_end_date_key %}
+Foreign key to dim_date for the retention period end date.
+{% enddocs %}
+
 ---
 
 ## Marts dimension columns
@@ -837,4 +850,48 @@ Number of currently active members in the account.
 
 {% docs col_usage_at %}
 Timestamp when the feature usage event occurred.
+{% enddocs %}
+
+---
+
+## Retention columns
+
+{% docs col_cohort_week_start_date %}
+Monday of the ISO week in which users activated. Defines the retention
+cohort boundary.
+{% enddocs %}
+
+{% docs col_retention_period %}
+Retention measurement period label. Eight fixed periods: W1 through W4
+(weekly), M2, M3, M6, M12 (monthly milestones measured as 7-day windows).
+{% enddocs %}
+
+{% docs col_period_offset_days %}
+Number of days from the cohort week start date to the beginning of the
+7-day retention measurement window.
+{% enddocs %}
+
+{% docs col_period_end_date %}
+Last date of the 7-day retention measurement window. Equals
+cohort_week_start_date plus period_offset_days plus 6.
+{% enddocs %}
+
+{% docs col_cohort_size %}
+Number of users who activated during the cohort week.
+{% enddocs %}
+
+{% docs col_retained_count %}
+Number of cohort users who had at least one event during the retention
+measurement window. Always less than or equal to cohort_size.
+{% enddocs %}
+
+{% docs col_retention_rate %}
+Fraction of cohort users retained in the measurement window. Equals
+retained_count divided by cohort_size, bounded between 0 and 1.
+{% enddocs %}
+
+{% docs col_is_period_complete %}
+Whether the retention measurement window has fully elapsed plus a 7-day
+buffer for late-arriving events. False for recent periods where data may
+still be incomplete.
 {% enddocs %}

--- a/models/intermediate/engagement/_models.yml
+++ b/models/intermediate/engagement/_models.yml
@@ -91,7 +91,7 @@ models:
               min_value: 24
 
   - name: int_experiment_metadata
-    description: Passthrough of experiment seed definitions into the intermediate layer.
+    description: '{{ doc("int_experiment_metadata") }}'
     config:
       tags:
         - intermediate

--- a/models/intermediate/intermediate.md
+++ b/models/intermediate/intermediate.md
@@ -57,6 +57,10 @@ User-level experiment exposure and conversion data. Parses experiment_flags
 JSON. Enforces 24-hour minimum exposure duration.
 {% enddocs %}
 
+{% docs int_experiment_metadata %}
+Passthrough of experiment seed definitions into the intermediate layer.
+{% enddocs %}
+
 ---
 
 ## Cross-domain

--- a/models/marts/core/_models.yml
+++ b/models/marts/core/_models.yml
@@ -381,3 +381,107 @@ models:
         description: '{{ doc("col_last_touch_channel") }}'
         tests:
           - not_null
+
+  - name: fct_retention_cohorts
+    description: '{{ doc("fct_retention_cohorts") }}'
+    config:
+      contract:
+        enforced: true
+      tags:
+        - marts
+      meta:
+        owner: analytics
+        pii: false
+        sla: daily
+        tier: 1
+    columns:
+      - name: retention_cohort_key
+        data_type: int64
+        description: '{{ doc("col_retention_cohort_key") }}'
+        tests:
+          - unique
+          - not_null
+
+      - name: cohort_week_start_date
+        data_type: date
+        description: '{{ doc("col_cohort_week_start_date") }}'
+        tests:
+          - not_null
+
+      - name: cohort_week_date_key
+        data_type: int64
+        description: '{{ doc("col_cohort_week_date_key") }}'
+        tests:
+          - not_null
+          - relationships:
+              to: ref('dim_date')
+              field: date_key
+
+      - name: retention_period
+        data_type: string
+        description: '{{ doc("col_retention_period") }}'
+        tests:
+          - not_null
+          - accepted_values:
+              arguments:
+                values:
+                  - W1
+                  - W2
+                  - W3
+                  - W4
+                  - M2
+                  - M3
+                  - M6
+                  - M12
+
+      - name: period_offset_days
+        data_type: int64
+        description: '{{ doc("col_period_offset_days") }}'
+        tests:
+          - not_null
+
+      - name: period_end_date
+        data_type: date
+        description: '{{ doc("col_period_end_date") }}'
+        tests:
+          - not_null
+
+      - name: period_end_date_key
+        data_type: int64
+        description: '{{ doc("col_period_end_date_key") }}'
+        tests:
+          - not_null
+          - relationships:
+              to: ref('dim_date')
+              field: date_key
+              where: "is_period_complete"
+
+      - name: cohort_size
+        data_type: int64
+        description: '{{ doc("col_cohort_size") }}'
+        tests:
+          - not_null
+
+      - name: retained_count
+        data_type: int64
+        description: '{{ doc("col_retained_count") }}'
+        tests:
+          - not_null
+
+      - name: retention_rate
+        data_type: float64
+        description: '{{ doc("col_retention_rate") }}'
+        tests:
+          - not_null
+
+      - name: is_period_complete
+        data_type: boolean
+        description: '{{ doc("col_is_period_complete") }}'
+        tests:
+          - not_null
+
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          combination_of_columns:
+            - cohort_week_start_date
+            - retention_period

--- a/models/marts/core/fct_retention_cohorts.sql
+++ b/models/marts/core/fct_retention_cohorts.sql
@@ -1,0 +1,114 @@
+with activated_users as (
+
+    select
+        user_id,
+        activation_at,
+        date_trunc(date(activation_at), isoweek) as cohort_week_start_date
+    from {{ ref('int_attribution') }}
+
+),
+
+retention_periods as (
+
+    select
+        retention_period,
+        period_offset_days
+    from
+        unnest([
+            struct('W1' as retention_period, 7 as period_offset_days),
+            struct('W2', 14),
+            struct('W3', 21),
+            struct('W4', 28),
+            struct('M2', 60),
+            struct('M3', 91),
+            struct('M6', 182),
+            struct('M12', 365)
+        ])
+
+),
+
+user_periods as (
+
+    select
+        au.user_id,
+        au.cohort_week_start_date,
+        rp.retention_period,
+        rp.period_offset_days,
+        date_add(
+            au.cohort_week_start_date,
+            interval rp.period_offset_days day
+        ) as period_start_date,
+        date_add(
+            au.cohort_week_start_date,
+            interval rp.period_offset_days + 6 day
+        ) as period_end_date
+    from activated_users as au
+    cross join retention_periods as rp
+
+),
+
+user_activity as (
+
+    select distinct
+        coalesce(e.user_id, i.user_id) as resolved_user_id,
+        date(e.event_time) as activity_date
+    from {{ ref('int_events_normalized') }} as e
+    left join {{ ref('int_identity_stitched') }} as i
+        on
+            e.anon_id = i.anon_id
+            and e.event_time >= i.valid_from
+            and e.event_time < coalesce(
+                i.valid_to, timestamp('9999-12-31')
+            )
+    where coalesce(e.user_id, i.user_id) is not null
+        and coalesce(e.user_id, i.user_id) in (
+            select user_id from activated_users
+        )
+
+),
+
+retention_measured as (
+
+    select
+        up.cohort_week_start_date,
+        up.retention_period,
+        up.period_offset_days,
+        up.period_end_date,
+        count(distinct up.user_id) as cohort_size,
+        count(distinct case
+            when ua.activity_date is not null then up.user_id
+        end) as retained_count
+    from user_periods as up
+    left join user_activity as ua
+        on
+            up.user_id = ua.resolved_user_id
+            and ua.activity_date
+            between up.period_start_date and up.period_end_date
+    group by all
+
+)
+
+select
+    farm_fingerprint(
+        concat(
+            cast(cohort_week_start_date as string),
+            '|',
+            retention_period
+        )
+    ) as retention_cohort_key,
+    cohort_week_start_date,
+    cast(
+        format_date('%Y%m%d', cohort_week_start_date) as int64
+    ) as cohort_week_date_key,
+    retention_period,
+    period_offset_days,
+    period_end_date,
+    cast(
+        format_date('%Y%m%d', period_end_date) as int64
+    ) as period_end_date_key,
+    cohort_size,
+    retained_count,
+    safe_divide(retained_count, cohort_size) as retention_rate,
+    date_add(period_end_date, interval 7 day) <= current_date()
+        as is_period_complete
+from retention_measured

--- a/models/marts/core/fct_retention_cohorts.sql
+++ b/models/marts/core/fct_retention_cohorts.sql
@@ -60,9 +60,10 @@ user_activity as (
             and e.event_time < coalesce(
                 i.valid_to, timestamp('9999-12-31')
             )
-    where coalesce(e.user_id, i.user_id) is not null
+    where
+        coalesce(e.user_id, i.user_id) is not null
         and coalesce(e.user_id, i.user_id) in (
-            select user_id from activated_users
+            select activated_users.user_id from activated_users
         )
 
 ),

--- a/models/marts/marts.md
+++ b/models/marts/marts.md
@@ -98,3 +98,11 @@ row per user x experiment. Extends bridge_user_experiments with conversion
 metrics (converted, conversion_at) and exposure duration. Composite PK
 (user_key + experiment_key).
 {% enddocs %}
+
+{% docs fct_retention_cohorts %}
+Pre-computed retention cohort fact sourced from attribution and normalized
+event data. Grain: one row per activation-week cohort x retention period.
+Eight retention periods (W1-W4, M2, M3, M6, M12) measured as 7-day activity
+windows at fixed day offsets from the cohort week start date (always a
+Monday). Only activated users are included in cohorts.
+{% enddocs %}

--- a/tests/invariants/invariants_fct_retention_cohorts_monday_alignment.sql
+++ b/tests/invariants/invariants_fct_retention_cohorts_monday_alignment.sql
@@ -1,0 +1,13 @@
+-- Validates that cohort_week_start_date is always a Monday (ISO week start).
+
+{{ config(
+    severity='error',
+    tags=['data_quality'],
+    description='cohort_week_start_date must always be a Monday'
+) }}
+
+select
+    cohort_week_start_date,
+    retention_period
+from {{ ref('fct_retention_cohorts') }}
+where extract(dayofweek from cohort_week_start_date) != 2

--- a/tests/invariants/invariants_fct_retention_cohorts_rate_bounds.sql
+++ b/tests/invariants/invariants_fct_retention_cohorts_rate_bounds.sql
@@ -1,0 +1,22 @@
+-- Validates that retention_rate is [0, 1], retained_count <= cohort_size,
+-- and cohort_size > 0.
+
+{{ config(
+    severity='error',
+    tags=['data_quality'],
+    description='retention_rate must be [0,1] and retained_count must be <= cohort_size'
+) }}
+
+select
+    cohort_week_start_date,
+    retention_period,
+    cohort_size,
+    retained_count,
+    retention_rate
+from {{ ref('fct_retention_cohorts') }}
+where
+    retention_rate < 0
+    or retention_rate > 1
+    or retained_count > cohort_size
+    or retained_count < 0
+    or cohort_size <= 0

--- a/tests/reconciliation/reconciliation_fct_retention_cohorts_cohort_size.sql
+++ b/tests/reconciliation/reconciliation_fct_retention_cohorts_cohort_size.sql
@@ -1,0 +1,40 @@
+-- Validates that cohort_size in fct_retention_cohorts matches the count of
+-- activated users per week in int_attribution.
+
+{{ config(
+    severity='error',
+    tags=['data_quality'],
+    description='cohort_size must equal count of activated users per cohort week in int_attribution'
+) }}
+
+with attribution_counts as (
+
+    select
+        date_trunc(date(activation_at), isoweek) as cohort_week_start_date,
+        count(*) as expected_cohort_size
+    from {{ ref('int_attribution') }}
+    group by all
+
+),
+
+retention_counts as (
+
+    select distinct
+        cohort_week_start_date,
+        cohort_size
+    from {{ ref('fct_retention_cohorts') }}
+
+)
+
+select
+    coalesce(a.cohort_week_start_date, r.cohort_week_start_date)
+        as cohort_week_start_date,
+    a.expected_cohort_size,
+    r.cohort_size as actual_cohort_size
+from attribution_counts as a
+full outer join retention_counts as r
+    on a.cohort_week_start_date = r.cohort_week_start_date
+where
+    a.expected_cohort_size != r.cohort_size
+    or a.expected_cohort_size is null
+    or r.cohort_size is null


### PR DESCRIPTION
## Summary

- Build `fct_retention_cohorts`: pre-computed retention at cohort-week x period grain (840 rows, 8 periods: W1-W4, M2, M3, M6, M12)
- Sources `int_attribution` for cohort universe, `int_events_normalized` + `int_identity_stitched` for identity-resolved activity detection
- Cross-model FK audit: all 35 existing FK tests confirmed complete, 2 new FK tests added for this model
- Fix pre-existing inline description on `int_experiment_metadata` (_models.yml:94)

## Changes

| File | Change |
|------|--------|
| `models/marts/core/fct_retention_cohorts.sql` | New SQL model (5 CTEs + final select) |
| `models/marts/core/_models.yml` | Schema entry with contract, meta, PK/FK/accepted_values tests |
| `docs/columns.md` | 11 new doc blocks (surrogate key, FKs, retention columns) |
| `models/marts/marts.md` | Model description doc block |
| `tests/invariants/invariants_fct_retention_cohorts_rate_bounds.sql` | Rate bounds + count invariant |
| `tests/invariants/invariants_fct_retention_cohorts_monday_alignment.sql` | Monday alignment invariant |
| `tests/reconciliation/reconciliation_fct_retention_cohorts_cohort_size.sql` | Cohort size vs int_attribution reconciliation |
| `models/intermediate/engagement/_models.yml` | Fix inline description → doc block |
| `models/intermediate/intermediate.md` | Add int_experiment_metadata doc block |
| `.gitignore` | Add .envrc |

## Test plan

- [x] `dbt build --exclude package:dbt_project_evaluator` — 496/496 PASS
- [x] `scripts/lint-doc-blocks.sh` — PASS (was failing before this PR)
- [x] `scripts/lint-model-names.sh` — PASS
- [x] Retention curve verified: W1 70.8% → M12 10.9% (monotonically decreasing)
- [x] Cohort sizes verified: exact match with int_attribution per-week counts
- [x] Cross-review: 3 findings addressed (doc wording, perf optimization, reconciliation test)
- [x] Self-review: 36 checks, all passed

Closes #26