### PR TITLE
fix: resolve 63 generic test deprecation warnings

### DIFF
--- a/models/intermediate/billing/_models.yml
+++ b/models/intermediate/billing/_models.yml
@@ -76,7 +76,8 @@ models:
         description: '{{ doc("col_days_since_previous_event") }}'
         tests:
           - dbt_expectations.expect_column_values_to_be_between:
-              min_value: 0
+              arguments:
+                min_value: 0
               config:
                 where: "days_since_previous_event is not null"
 
@@ -87,9 +88,10 @@ models:
         - intermediate
     tests:
       - dbt_utils.unique_combination_of_columns:
-          combination_of_columns:
-            - account_id
-            - subscription_event_id
+          arguments:
+            combination_of_columns:
+              - account_id
+              - subscription_event_id
     columns:
       - name: account_id
         description: '{{ doc("col_account_id") }}'
@@ -116,12 +118,13 @@ models:
         tests:
           - not_null
           - accepted_values:
-              values:
-                - new
-                - expansion
-                - contraction
-                - churn
-                - reactivation
+              arguments:
+                values:
+                  - new
+                  - expansion
+                  - contraction
+                  - churn
+                  - reactivation
 
       - name: mrr_before
         description: '{{ doc("col_mrr_before") }}'

--- a/models/intermediate/cross_domain/_models.yml
+++ b/models/intermediate/cross_domain/_models.yml
@@ -53,7 +53,8 @@ models:
         description: '{{ doc("col_resolution_time_hours") }}'
         tests:
           - dbt_expectations.expect_column_values_to_be_between:
-              min_value: 0
+              arguments:
+                min_value: 0
               config:
                 where: "resolution_time_hours is not null"
 
@@ -61,7 +62,8 @@ models:
         description: '{{ doc("col_first_response_hours") }}'
         tests:
           - dbt_expectations.expect_column_values_to_be_between:
-              min_value: 0
+              arguments:
+                min_value: 0
               config:
                 where: "first_response_hours is not null"
 
@@ -294,7 +296,8 @@ models:
         description: '{{ doc("col_time_to_conversion_days") }}'
         tests:
           - dbt_utils.expression_is_true:
-              expression: "<= 30 or time_to_conversion_days is null"
+              arguments:
+                expression: "<= 30 or time_to_conversion_days is null"
 
   - name: int_account_health
     description: '{{ doc("int_account_health") }}'
@@ -313,32 +316,36 @@ models:
         tests:
           - not_null
           - dbt_expectations.expect_column_values_to_be_between:
-              min_value: 0
-              max_value: 100
+              arguments:
+                min_value: 0
+                max_value: 100
 
       - name: activity_score
         description: '{{ doc("col_activity_score") }}'
         tests:
           - not_null
           - dbt_expectations.expect_column_values_to_be_between:
-              min_value: 0
-              max_value: 100
+              arguments:
+                min_value: 0
+                max_value: 100
 
       - name: billing_score
         description: '{{ doc("col_billing_score") }}'
         tests:
           - not_null
           - dbt_expectations.expect_column_values_to_be_between:
-              min_value: 0
-              max_value: 100
+              arguments:
+                min_value: 0
+                max_value: 100
 
       - name: support_score
         description: '{{ doc("col_support_score") }}'
         tests:
           - not_null
           - dbt_expectations.expect_column_values_to_be_between:
-              min_value: 0
-              max_value: 100
+              arguments:
+                min_value: 0
+                max_value: 100
 
       - name: calculated_at
         description: '{{ doc("col_calculated_at") }}'

--- a/models/intermediate/engagement/_models.yml
+++ b/models/intermediate/engagement/_models.yml
@@ -8,9 +8,10 @@ models:
         - intermediate
     tests:
       - dbt_utils.unique_combination_of_columns:
-          combination_of_columns:
-            - user_id
-            - snapshot_week_start
+          arguments:
+            combination_of_columns:
+              - user_id
+              - snapshot_week_start
     columns:
       - name: user_id
         description: '{{ doc("col_user_id") }}'
@@ -27,11 +28,12 @@ models:
         tests:
           - not_null
           - accepted_values:
-              values:
-                - pre_active
-                - active
-                - dormant
-                - disengaged
+              arguments:
+                values:
+                  - pre_active
+                  - active
+                  - dormant
+                  - disengaged
 
       - name: is_re_engaged
         description: '{{ doc("col_is_re_engaged") }}'
@@ -51,9 +53,10 @@ models:
         - intermediate
     tests:
       - dbt_utils.unique_combination_of_columns:
-          combination_of_columns:
-            - user_id
-            - experiment_id
+          arguments:
+            combination_of_columns:
+              - user_id
+              - experiment_id
     columns:
       - name: user_id
         description: '{{ doc("col_user_id") }}'
@@ -88,7 +91,8 @@ models:
         tests:
           - not_null
           - dbt_expectations.expect_column_values_to_be_between:
-              min_value: 24
+              arguments:
+                min_value: 24
 
   - name: int_experiment_metadata
     description: '{{ doc("int_experiment_metadata") }}'

--- a/models/intermediate/product/_models.yml
+++ b/models/intermediate/product/_models.yml
@@ -130,9 +130,10 @@ models:
         - intermediate
     tests:
       - dbt_utils.unique_combination_of_columns:
-          combination_of_columns:
-            - anon_id
-            - valid_from
+          arguments:
+            combination_of_columns:
+              - anon_id
+              - valid_from
     columns:
       - name: anon_id
         description: '{{ doc("col_anon_id") }}'
@@ -157,9 +158,10 @@ models:
         tests:
           - not_null
           - accepted_values:
-              values:
-                - last_touch
-                - historical
+              arguments:
+                values:
+                  - last_touch
+                  - historical
 
   - name: int_account_memberships
     description: '{{ doc("int_account_memberships") }}'
@@ -168,10 +170,11 @@ models:
         - intermediate
     tests:
       - dbt_utils.unique_combination_of_columns:
-          combination_of_columns:
-            - user_id
-            - account_id
-            - valid_from
+          arguments:
+            combination_of_columns:
+              - user_id
+              - account_id
+              - valid_from
     columns:
       - name: user_id
         description: '{{ doc("col_user_id") }}'
@@ -199,7 +202,8 @@ models:
         tests:
           - not_null
           - dbt_expectations.expect_column_values_to_be_between:
-              min_value: 0
+              arguments:
+                min_value: 0
 
   - name: int_sessions
     description: '{{ doc("int_sessions") }}'
@@ -236,14 +240,16 @@ models:
         tests:
           - not_null
           - dbt_expectations.expect_column_values_to_be_between:
-              min_value: 0
+              arguments:
+                min_value: 0
 
       - name: event_count
         description: '{{ doc("col_event_count") }}'
         tests:
           - not_null
           - dbt_expectations.expect_column_values_to_be_between:
-              min_value: 1
+              arguments:
+                min_value: 1
 
       - name: page_view_count
         description: '{{ doc("col_page_view_count") }}'
@@ -278,9 +284,10 @@ models:
         - intermediate
     tests:
       - dbt_utils.unique_combination_of_columns:
-          combination_of_columns:
-            - user_id
-            - stage
+          arguments:
+            combination_of_columns:
+              - user_id
+              - stage
     columns:
       - name: user_id
         description: '{{ doc("col_user_id") }}'
@@ -292,12 +299,13 @@ models:
         tests:
           - not_null
           - accepted_values:
-              values:
-                - page_view
-                - signup
-                - activation
-                - feature_use
-                - checkout_start
+              arguments:
+                values:
+                  - page_view
+                  - signup
+                  - activation
+                  - feature_use
+                  - checkout_start
 
       - name: stage_reached_at
         description: '{{ doc("col_stage_reached_at") }}'

--- a/models/marts/billing/_models.yml
+++ b/models/marts/billing/_models.yml
@@ -46,8 +46,9 @@ models:
         tests:
           - not_null
           - relationships:
-              to: ref('dim_users')
-              field: user_key
+              arguments:
+                to: ref('dim_users')
+                field: user_key
 
       - name: account_id
         data_type: string
@@ -61,8 +62,9 @@ models:
         tests:
           - not_null
           - relationships:
-              to: ref('dim_accounts')
-              field: account_key
+              arguments:
+                to: ref('dim_accounts')
+                field: account_key
 
       - name: event_date_key
         data_type: int64
@@ -70,8 +72,9 @@ models:
         tests:
           - not_null
           - relationships:
-              to: ref('dim_date')
-              field: date_key
+              arguments:
+                to: ref('dim_date')
+                field: date_key
 
       - name: event_time
         data_type: timestamp
@@ -191,8 +194,9 @@ models:
         tests:
           - not_null
           - relationships:
-              to: ref('dim_accounts')
-              field: account_key
+              arguments:
+                to: ref('dim_accounts')
+                field: account_key
 
       - name: subscription_event_id
         data_type: string
@@ -212,8 +216,9 @@ models:
         tests:
           - not_null
           - relationships:
-              to: ref('dim_date')
-              field: date_key
+              arguments:
+                to: ref('dim_date')
+                field: date_key
 
       - name: movement_date
         data_type: date
@@ -255,9 +260,10 @@ models:
 
     tests:
       - dbt_utils.unique_combination_of_columns:
-          combination_of_columns:
-            - account_id
-            - subscription_event_id
+          arguments:
+            combination_of_columns:
+              - account_id
+              - subscription_event_id
 
   - name: fct_invoices
     description: '{{ doc("fct_invoices") }}'
@@ -304,8 +310,9 @@ models:
         tests:
           - not_null
           - relationships:
-              to: ref('dim_users')
-              field: user_key
+              arguments:
+                to: ref('dim_users')
+                field: user_key
 
       - name: account_id
         data_type: string
@@ -319,8 +326,9 @@ models:
         tests:
           - not_null
           - relationships:
-              to: ref('dim_accounts')
-              field: account_key
+              arguments:
+                to: ref('dim_accounts')
+                field: account_key
 
       - name: issued_date_key
         data_type: int64
@@ -328,8 +336,9 @@ models:
         tests:
           - not_null
           - relationships:
-              to: ref('dim_date')
-              field: date_key
+              arguments:
+                to: ref('dim_date')
+                field: date_key
 
       - name: issued_at
         data_type: timestamp

--- a/models/marts/core/_models.yml
+++ b/models/marts/core/_models.yml
@@ -72,8 +72,9 @@ models:
         description: '{{ doc("col_first_touch_channel_key") }}'
         tests:
           - relationships:
-              to: ref('dim_channels')
-              field: channel_key
+              arguments:
+                to: ref('dim_channels')
+                field: channel_key
               where: "first_touch_channel_key is not null"
 
       - name: last_touch_channel_key
@@ -81,8 +82,9 @@ models:
         description: '{{ doc("col_last_touch_channel_key") }}'
         tests:
           - relationships:
-              to: ref('dim_channels')
-              field: channel_key
+              arguments:
+                to: ref('dim_channels')
+                field: channel_key
               where: "last_touch_channel_key is not null"
 
       - name: engagement_state
@@ -172,8 +174,9 @@ models:
         description: '{{ doc("col_acquisition_channel_key") }}'
         tests:
           - relationships:
-              to: ref('dim_channels')
-              field: channel_key
+              arguments:
+                to: ref('dim_channels')
+                field: channel_key
               where: "acquisition_channel_key is not null"
 
       - name: acquisition_date
@@ -232,8 +235,9 @@ models:
         tests:
           - not_null
           - relationships:
-              to: ref('dim_users')
-              field: user_key
+              arguments:
+                to: ref('dim_users')
+                field: user_key
 
       - name: signup_date_key
         data_type: int64
@@ -241,8 +245,9 @@ models:
         tests:
           - not_null
           - relationships:
-              to: ref('dim_date')
-              field: date_key
+              arguments:
+                to: ref('dim_date')
+                field: date_key
 
       - name: signup_at
         data_type: timestamp
@@ -274,8 +279,9 @@ models:
         tests:
           - not_null
           - relationships:
-              to: ref('dim_channels')
-              field: channel_key
+              arguments:
+                to: ref('dim_channels')
+                field: channel_key
 
       - name: platform
         data_type: string
@@ -334,8 +340,9 @@ models:
         tests:
           - not_null
           - relationships:
-              to: ref('dim_users')
-              field: user_key
+              arguments:
+                to: ref('dim_users')
+                field: user_key
 
       - name: activation_date_key
         data_type: int64
@@ -343,8 +350,9 @@ models:
         tests:
           - not_null
           - relationships:
-              to: ref('dim_date')
-              field: date_key
+              arguments:
+                to: ref('dim_date')
+                field: date_key
 
       - name: activation_at
         data_type: timestamp
@@ -358,8 +366,9 @@ models:
         tests:
           - not_null
           - relationships:
-              to: ref('dim_channels')
-              field: channel_key
+              arguments:
+                to: ref('dim_channels')
+                field: channel_key
 
       - name: last_touch_channel_key
         data_type: int64
@@ -367,8 +376,9 @@ models:
         tests:
           - not_null
           - relationships:
-              to: ref('dim_channels')
-              field: channel_key
+              arguments:
+                to: ref('dim_channels')
+                field: channel_key
 
       - name: first_touch_channel
         data_type: string
@@ -414,8 +424,9 @@ models:
         tests:
           - not_null
           - relationships:
-              to: ref('dim_date')
-              field: date_key
+              arguments:
+                to: ref('dim_date')
+                field: date_key
 
       - name: retention_period
         data_type: string
@@ -452,8 +463,9 @@ models:
         tests:
           - not_null
           - relationships:
-              to: ref('dim_date')
-              field: date_key
+              arguments:
+                to: ref('dim_date')
+                field: date_key
               where: "is_period_complete"
 
       - name: cohort_size
@@ -482,6 +494,7 @@ models:
 
     tests:
       - dbt_utils.unique_combination_of_columns:
-          combination_of_columns:
-            - cohort_week_start_date
-            - retention_period
+          arguments:
+            combination_of_columns:
+              - cohort_week_start_date
+              - retention_period

--- a/models/marts/marketing/_models.yml
+++ b/models/marts/marketing/_models.yml
@@ -34,8 +34,9 @@ models:
         tests:
           - not_null
           - relationships:
-              to: ref('dim_date')
-              field: date_key
+              arguments:
+                to: ref('dim_date')
+                field: date_key
 
       - name: channel
         data_type: string
@@ -49,8 +50,9 @@ models:
         tests:
           - not_null
           - relationships:
-              to: ref('dim_channels')
-              field: channel_key
+              arguments:
+                to: ref('dim_channels')
+                field: channel_key
 
       - name: campaign_id
         data_type: string

--- a/models/marts/product/_models.yml
+++ b/models/marts/product/_models.yml
@@ -34,8 +34,9 @@ models:
         tests:
           - not_null
           - relationships:
-              to: ref('dim_date')
-              field: date_key
+              arguments:
+                to: ref('dim_date')
+                field: date_key
 
       - name: platform
         data_type: string
@@ -151,8 +152,9 @@ models:
         tests:
           - not_null
           - relationships:
-              to: ref('dim_users')
-              field: user_key
+              arguments:
+                to: ref('dim_users')
+                field: user_key
 
       - name: user_id
         data_type: string
@@ -166,8 +168,9 @@ models:
         tests:
           - not_null
           - relationships:
-              to: ref('dim_experiments')
-              field: experiment_key
+              arguments:
+                to: ref('dim_experiments')
+                field: experiment_key
 
       - name: variant
         data_type: string
@@ -183,9 +186,10 @@ models:
 
     tests:
       - dbt_utils.unique_combination_of_columns:
-          combination_of_columns:
-            - user_key
-            - experiment_key
+          arguments:
+            combination_of_columns:
+              - user_key
+              - experiment_key
 
   - name: fct_feature_usage
     description: '{{ doc("fct_feature_usage") }}'
@@ -226,8 +230,9 @@ models:
         tests:
           - not_null
           - relationships:
-              to: ref('dim_users')
-              field: user_key
+              arguments:
+                to: ref('dim_users')
+                field: user_key
 
       - name: account_id
         data_type: string
@@ -238,8 +243,9 @@ models:
         description: '{{ doc("col_account_key") }}'
         tests:
           - relationships:
-              to: ref('dim_accounts')
-              field: account_key
+              arguments:
+                to: ref('dim_accounts')
+                field: account_key
               where: "account_key is not null"
 
       - name: usage_date_key
@@ -248,8 +254,9 @@ models:
         tests:
           - not_null
           - relationships:
-              to: ref('dim_date')
-              field: date_key
+              arguments:
+                to: ref('dim_date')
+                field: date_key
 
       - name: usage_at
         data_type: timestamp
@@ -308,8 +315,9 @@ models:
           - unique
           - not_null
           - relationships:
-              to: ref('dim_sessions')
-              field: session_key
+              arguments:
+                to: ref('dim_sessions')
+                field: session_key
 
       - name: session_id
         data_type: string
@@ -330,8 +338,9 @@ models:
         tests:
           - not_null
           - relationships:
-              to: ref('dim_users')
-              field: user_key
+              arguments:
+                to: ref('dim_users')
+                field: user_key
 
       - name: session_date_key
         data_type: int64
@@ -339,8 +348,9 @@ models:
         tests:
           - not_null
           - relationships:
-              to: ref('dim_date')
-              field: date_key
+              arguments:
+                to: ref('dim_date')
+                field: date_key
 
       - name: session_start_at
         data_type: timestamp
@@ -419,8 +429,9 @@ models:
         tests:
           - not_null
           - relationships:
-              to: ref('dim_users')
-              field: user_key
+              arguments:
+                to: ref('dim_users')
+                field: user_key
 
       - name: experiment_id
         data_type: string
@@ -434,8 +445,9 @@ models:
         tests:
           - not_null
           - relationships:
-              to: ref('dim_experiments')
-              field: experiment_key
+              arguments:
+                to: ref('dim_experiments')
+                field: experiment_key
 
       - name: variant
         data_type: string
@@ -460,8 +472,9 @@ models:
         tests:
           - not_null
           - relationships:
-              to: ref('dim_date')
-              field: date_key
+              arguments:
+                to: ref('dim_date')
+                field: date_key
 
       - name: converted
         data_type: boolean
@@ -481,6 +494,7 @@ models:
 
     tests:
       - dbt_utils.unique_combination_of_columns:
-          combination_of_columns:
-            - user_key
-            - experiment_key
+          arguments:
+            combination_of_columns:
+              - user_key
+              - experiment_key

--- a/models/marts/support/_models.yml
+++ b/models/marts/support/_models.yml
@@ -40,8 +40,9 @@ models:
         tests:
           - not_null
           - relationships:
-              to: ref('dim_users')
-              field: user_key
+              arguments:
+                to: ref('dim_users')
+                field: user_key
 
       - name: account_id
         data_type: string
@@ -55,8 +56,9 @@ models:
         tests:
           - not_null
           - relationships:
-              to: ref('dim_accounts')
-              field: account_key
+              arguments:
+                to: ref('dim_accounts')
+                field: account_key
 
       - name: created_date_key
         data_type: int64
@@ -64,8 +66,9 @@ models:
         tests:
           - not_null
           - relationships:
-              to: ref('dim_date')
-              field: date_key
+              arguments:
+                to: ref('dim_date')
+                field: date_key
 
       - name: created_at
         data_type: timestamp


### PR DESCRIPTION
## Summary
- Nest all generic test arguments under the `arguments` property across 9 `_models.yml` files, as required by dbt 1.11+
- Affected tests: `relationships`, `accepted_values`, `dbt_utils.unique_combination_of_columns`, `dbt_expectations.expect_column_values_to_be_between`, `dbt_utils.expression_is_true`
- Test config properties (`where`, `config`) remain at the top level as expected

## Verification
- `dbt parse --no-partial-parse` produces 0 `MissingArgumentsPropertyInGenericTestDeprecation` warnings (was 63)
- No other new warnings introduced

Closes #49