### PR TITLE
feat: convert int_events_normalized to incremental materialization

### DIFF
--- a/models/intermediate/product/_models.yml
+++ b/models/intermediate/product/_models.yml
@@ -4,9 +4,17 @@ models:
   - name: int_events_normalized
     description: '{{ doc("int_events_normalized") }}'
     config:
-      materialized: view
+      materialized: incremental
+      unique_key: event_id
+      partition_by:
+        field: event_date
+        data_type: date
+        granularity: day
+      incremental_strategy: merge
+      on_schema_change: fail
       tags:
         - intermediate
+        - incremental
     columns:
       - name: event_id
         description: '{{ doc("col_event_id") }}'

--- a/models/intermediate/product/int_events_normalized.sql
+++ b/models/intermediate/product/int_events_normalized.sql
@@ -1,6 +1,3 @@
--- TODO: convert to incremental materialization (issue #21)
-{{ config(materialized='view') }}
-
 with source as (
 
     select
@@ -43,6 +40,9 @@ with source as (
             order by _loaded_at asc, ingest_time asc
         ) as _dedup_row_num
     from {{ ref('stg_funnel__events') }}
+    {% if is_incremental() %}
+        where _loaded_at >= timestamp_sub(current_timestamp(), interval 36 hour)
+    {% endif %}
 
 )
 


### PR DESCRIPTION
Closes #21

## Summary

- Converts `int_events_normalized` from view to incremental (merge on `event_id`, partition by `event_date`)
- Config placed in `_models.yml` per project convention (no Jinja config blocks in SQL)
- 36-hour lookback filter on `_loaded_at` to catch late-arriving duplicate events — uses load timestamp rather than event timestamp so late-arriving dupes with old `event_time` are not missed
- Removes the redundant `{{ config(materialized='view') }}` line from the SQL file
- Existing `row_number()` dedup handles within-window duplicates; merge strategy handles dedup against the existing table

## Design decisions

**Why `_loaded_at` for the lookback window, not `event_time`:** A duplicate event arriving late has an old `event_time` but a recent `_loaded_at`. Filtering on `event_time` would miss it. Filtering on `_loaded_at` catches any row loaded in the last 36h regardless of when the event occurred, then the merge deduplicates by `event_id`.

**Why `on_schema_change: fail`:** Prevents silent schema drift on an incremental table. Any column addition requires an explicit `--full-refresh`.

## Validation

- Full refresh: `dbt build --select int_events_normalized --full-refresh`
- Incremental run: `dbt build --select int_events_normalized` (expects 0 new rows with static synthetic data)
- All tests: `dbt test --select int_events_normalized`