### PR TITLE
feat: governance — exposures, invoice invariants, previous_plan test

### DIFF
--- a/models/marts/billing/_models.yml
+++ b/models/marts/billing/_models.yml
@@ -115,6 +115,16 @@ models:
       - name: previous_plan
         data_type: string
         description: '{{ doc("col_previous_plan") }}'
+        data_tests:
+          - accepted_values:
+              arguments:
+                values:
+                  - free
+                  - starter
+                  - pro
+                  - enterprise
+              config:
+                where: "previous_plan is not null"
 
       - name: billing_cycle
         data_type: string

--- a/models/marts/exposures.yml
+++ b/models/marts/exposures.yml
@@ -1,0 +1,42 @@
+version: 2
+
+exposures:
+  - name: product_analytics_dashboard
+    type: dashboard
+    maturity: medium
+    owner:
+      name: Analytics Team
+      email: analytics@company.com
+    depends_on:
+      - ref('fct_sessions')
+      - ref('fct_feature_usage')
+      - ref('fct_signups')
+      - ref('fct_activations')
+      - ref('dim_users')
+      - ref('dim_accounts')
+      - ref('dim_sessions')
+
+  - name: revenue_dashboard
+    type: dashboard
+    maturity: medium
+    owner:
+      name: Analytics Team
+      email: analytics@company.com
+    depends_on:
+      - ref('fct_mrr_movements')
+      - ref('fct_subscriptions')
+      - ref('fct_invoices')
+      - ref('dim_accounts')
+
+  - name: growth_and_retention_dashboard
+    type: dashboard
+    maturity: medium
+    owner:
+      name: Analytics Team
+      email: analytics@company.com
+    depends_on:
+      - ref('fct_retention_cohorts')
+      - ref('fct_marketing_spend')
+      - ref('fct_experiment_exposures')
+      - ref('dim_channels')
+      - ref('dim_experiments')

--- a/tests/invariants/invariants_fct_invoices_is_paid_consistency.sql
+++ b/tests/invariants/invariants_fct_invoices_is_paid_consistency.sql
@@ -1,0 +1,15 @@
+-- Validates is_paid is true iff status = 'paid'.
+-- Catches logic drift between the boolean flag and the status enum.
+
+{{ config(
+    severity='error',
+    tags=['data_quality'],
+    description='Assert is_paid boolean is consistent with status = paid in fct_invoices'
+) }}
+
+select
+    invoice_id,
+    status,
+    is_paid
+from {{ ref('fct_invoices') }}
+where (status = 'paid') != is_paid

--- a/tests/invariants/invariants_fct_invoices_net_amount_formula.sql
+++ b/tests/invariants/invariants_fct_invoices_net_amount_formula.sql
@@ -1,0 +1,17 @@
+-- Validates net_amount = amount - refund_amount.
+-- Computed in int_invoices_prep and passed through to fct_invoices.
+
+{{ config(
+    severity='error',
+    tags=['data_quality'],
+    description='Assert net_amount equals amount minus refund_amount in fct_invoices'
+) }}
+
+select
+    invoice_id,
+    amount,
+    refund_amount,
+    net_amount,
+    amount - refund_amount as expected_net_amount
+from {{ ref('fct_invoices') }}
+where amount - refund_amount != net_amount


### PR DESCRIPTION
## Summary
- `models/marts/exposures.yml`: 3 dbt exposures documenting downstream consumers of mart models (product analytics dashboard, revenue dashboard, growth & retention dashboard)
- `tests/invariants/invariants_fct_invoices_net_amount_formula.sql`: singular test asserting `net_amount = amount - refund_amount`
- `tests/invariants/invariants_fct_invoices_is_paid_consistency.sql`: singular test asserting `is_paid` is consistent with `status = 'paid'`
- `models/marts/billing/_models.yml`: `accepted_values` test on `fct_subscriptions.previous_plan` with `where: "previous_plan is not null"` (nullable column — first-time subscribers have no prior plan)

## Test plan
- [x] `scripts/lint-doc-blocks.sh` passes clean
- [ ] CI: dbt build + new singular tests pass
- [ ] CI: dbt-project-evaluator clean
- [ ] `dbt source freshness` passes

Closes #27