### PR TITLE
test: O-7 fanout detection and export vs semantic reconciliation

### DIFF
--- a/tests/fanout/fanout_fct_mrr_movements_vs_int_mrr_movements.sql
+++ b/tests/fanout/fanout_fct_mrr_movements_vs_int_mrr_movements.sql
@@ -1,0 +1,22 @@
+-- Validates fct_mrr_movements row count does not exceed int_mrr_movements by more than 1%.
+-- int_mrr_movements excludes trial events (trial_start, trial_end), so mart and intermediate
+-- counts should be equal. Any ratio > 1.01 indicates a bad join in mart assembly.
+
+{{ config(
+    severity='error',
+    tags=['data_quality'],
+    description='Assert fct_mrr_movements count does not exceed int_mrr_movements by more than 1%'
+) }}
+
+with counts as (
+    select
+        (select count(*) from {{ ref('fct_mrr_movements') }})          as mart_count,
+        (select count(*) from {{ ref('int_mrr_movements') }})          as intermediate_count
+)
+
+select
+    mart_count,
+    intermediate_count,
+    round(safe_divide(mart_count, intermediate_count), 4)              as fanout_ratio
+from counts
+where mart_count > intermediate_count * 1.01

--- a/tests/fanout/fanout_fct_mrr_movements_vs_int_mrr_movements.sql
+++ b/tests/fanout/fanout_fct_mrr_movements_vs_int_mrr_movements.sql
@@ -1,11 +1,11 @@
--- Validates fct_mrr_movements row count does not exceed int_mrr_movements by more than 1%.
+-- Validates fct_mrr_movements row count exactly equals int_mrr_movements.
 -- int_mrr_movements excludes trial events (trial_start, trial_end), so mart and intermediate
--- counts should be equal. Any ratio > 1.01 indicates a bad join in mart assembly.
+-- counts must be equal. Any overage indicates a bad join in mart assembly.
 
 {{ config(
     severity='error',
     tags=['data_quality'],
-    description='Assert fct_mrr_movements count does not exceed int_mrr_movements by more than 1%'
+    description='Assert fct_mrr_movements count exactly equals int_mrr_movements (1:1 passthrough)'
 ) }}
 
 with counts as (
@@ -19,4 +19,4 @@ select
     intermediate_count,
     round(safe_divide(mart_count, intermediate_count), 4)              as fanout_ratio
 from counts
-where mart_count > intermediate_count * 1.01
+where mart_count > intermediate_count

--- a/tests/fanout/fanout_fct_sessions_vs_int_sessions.sql
+++ b/tests/fanout/fanout_fct_sessions_vs_int_sessions.sql
@@ -1,11 +1,10 @@
--- Validates fct_sessions row count does not exceed int_sessions by more than 1%.
--- Detects accidental fan-out from a bad join in mart assembly.
--- fct_sessions is assembled 1:1 from int_sessions — any ratio > 1.01 indicates a bad join.
+-- Validates fct_sessions row count exactly equals int_sessions.
+-- fct_sessions is a 1:1 passthrough from int_sessions — any overage indicates a bad join.
 
 {{ config(
     severity='error',
     tags=['data_quality'],
-    description='Assert fct_sessions count does not exceed int_sessions by more than 1%'
+    description='Assert fct_sessions count exactly equals int_sessions (1:1 passthrough)'
 ) }}
 
 with counts as (
@@ -19,4 +18,4 @@ select
     intermediate_count,
     round(safe_divide(mart_count, intermediate_count), 4)          as fanout_ratio
 from counts
-where mart_count > intermediate_count * 1.01
+where mart_count > intermediate_count

--- a/tests/fanout/fanout_fct_sessions_vs_int_sessions.sql
+++ b/tests/fanout/fanout_fct_sessions_vs_int_sessions.sql
@@ -1,0 +1,22 @@
+-- Validates fct_sessions row count does not exceed int_sessions by more than 1%.
+-- Detects accidental fan-out from a bad join in mart assembly.
+-- fct_sessions is assembled 1:1 from int_sessions — any ratio > 1.01 indicates a bad join.
+
+{{ config(
+    severity='error',
+    tags=['data_quality'],
+    description='Assert fct_sessions count does not exceed int_sessions by more than 1%'
+) }}
+
+with counts as (
+    select
+        (select count(*) from {{ ref('fct_sessions') }})           as mart_count,
+        (select count(*) from {{ ref('int_sessions') }})           as intermediate_count
+)
+
+select
+    mart_count,
+    intermediate_count,
+    round(safe_divide(mart_count, intermediate_count), 4)          as fanout_ratio
+from counts
+where mart_count > intermediate_count * 1.01

--- a/tests/reconciliation/reconciliation_fct_mrr_movements_vs_int.sql
+++ b/tests/reconciliation/reconciliation_fct_mrr_movements_vs_int.sql
@@ -1,0 +1,42 @@
+-- Validates sum(mrr_delta) per account is consistent between int_mrr_movements and fct_mrr_movements.
+-- Tests that mart assembly did not alter, drop, or duplicate any MRR delta values.
+-- Tolerance: 0.01, matching the precision used in reconciliation_int_mrr_movements_net_mrr.sql.
+--
+-- A full outer join surfaces three failure modes:
+--   1. account_id in intermediate but missing from mart (dropped in assembly)
+--   2. account_id in mart but missing from intermediate (introduced in assembly)
+--   3. sum(mrr_delta) differs by more than tolerance (value altered in assembly)
+
+{{ config(
+    severity='error',
+    tags=['data_quality'],
+    description='Assert mrr_delta totals per account are consistent between int_mrr_movements and fct_mrr_movements'
+) }}
+
+with intermediate_totals as (
+    select
+        account_id,
+        sum(mrr_delta)  as total_mrr_delta_int
+    from {{ ref('int_mrr_movements') }}
+    group by account_id
+),
+
+mart_totals as (
+    select
+        account_id,
+        sum(mrr_delta)  as total_mrr_delta_mart
+    from {{ ref('fct_mrr_movements') }}
+    group by account_id
+)
+
+select
+    coalesce(i.account_id, m.account_id)    as account_id,
+    i.total_mrr_delta_int,
+    m.total_mrr_delta_mart
+from intermediate_totals i
+full outer join mart_totals m
+    on i.account_id = m.account_id
+where
+    i.account_id is null
+    or m.account_id is null
+    or abs(i.total_mrr_delta_int - m.total_mrr_delta_mart) > 0.01


### PR DESCRIPTION
## Summary
- `tests/fanout/fanout_fct_sessions_vs_int_sessions.sql`: fct_sessions row count ≤ int_sessions × 1.01
- `tests/fanout/fanout_fct_mrr_movements_vs_int_mrr_movements.sql`: same pattern for MRR movements
- `tests/reconciliation/reconciliation_fct_mrr_movements_vs_int.sql`: sum(mrr_delta) per account consistent between intermediate and mart layers (full outer join, tolerance 0.01)

## Test plan
- [x] `scripts/lint-doc-blocks.sh` passes clean
- [ ] CI: dbt parse + build + all new tests pass

Closes #294