### PR TITLE
fix: anchor incremental lookback to max(_loaded_at) of last run

### DIFF
--- a/models/intermediate/CLAUDE.md
+++ b/models/intermediate/CLAUDE.md
@@ -5,7 +5,7 @@ All business logic lives here. Dedup, sessionization, identity stitching, attrib
 
 ## Conventions
 - Materialized: view (default). Use table only if query is too heavy for downstream.
-- Exception: `int_events_normalized` is incremental (merge on event_id, 36h lookback)
+- Exception: `int_events_normalized` is incremental (merge on event_id, 36h lookback anchored to max(_loaded_at) of last run — not current_timestamp)
 - Naming: `int_{concept}` (suffixes: `_prep` for source-specific prep, `_unioned` for multi-source union; subdirectory provides domain context)
 - `ref()` staging or other intermediate models only — never `source()`. Exception: seeds containing static reference data (e.g., `experiment_metadata`) are allowed as refs.
 - No `contract.enforced` (intermediate is internal)

--- a/models/intermediate/intermediate.md
+++ b/models/intermediate/intermediate.md
@@ -3,7 +3,9 @@
 {% docs int_events_normalized %}
 Canonical dedup on event_id. Keeps the earliest row by _loaded_at when
 duplicates exist (~0.5% of source events). Single source of truth for all
-downstream event consumption.
+downstream event consumption. Incremental merge on event_id with a 36-hour
+lookback from the last processed _loaded_at, catching late arrivals without
+a full-refresh.
 {% enddocs %}
 
 ---

--- a/models/intermediate/product/int_events_normalized.sql
+++ b/models/intermediate/product/int_events_normalized.sql
@@ -41,7 +41,10 @@ with source as (
         ) as _dedup_row_num
     from {{ ref('stg_funnel__events') }}
     {% if is_incremental() %}
-        where _loaded_at >= timestamp_sub(current_timestamp(), interval 36 hour)
+        where _loaded_at >= timestamp_sub(
+            (select max(_loaded_at) from {{ this }}),
+            interval 36 hour
+        )
     {% endif %}
 
 )

--- a/models/intermediate/product/int_events_normalized.sql
+++ b/models/intermediate/product/int_events_normalized.sql
@@ -42,7 +42,7 @@ with source as (
     from {{ ref('stg_funnel__events') }} as stg
     {% if is_incremental() %}
         where stg._loaded_at >= timestamp_sub(
-            (select max(_loaded_at) from {{ this }}),
+            (select max(t._loaded_at) from {{ this }} as t),
             interval 36 hour
         )
     {% endif %}

--- a/models/intermediate/product/int_events_normalized.sql
+++ b/models/intermediate/product/int_events_normalized.sql
@@ -39,9 +39,9 @@ with source as (
             partition by event_id
             order by _loaded_at asc, ingest_time asc
         ) as _dedup_row_num
-    from {{ ref('stg_funnel__events') }}
+    from {{ ref('stg_funnel__events') }} as stg
     {% if is_incremental() %}
-        where _loaded_at >= timestamp_sub(  -- noqa: RF02
+        where stg._loaded_at >= timestamp_sub(
             (select max(_loaded_at) from {{ this }}),
             interval 36 hour
         )

--- a/models/intermediate/product/int_events_normalized.sql
+++ b/models/intermediate/product/int_events_normalized.sql
@@ -41,7 +41,7 @@ with source as (
         ) as _dedup_row_num
     from {{ ref('stg_funnel__events') }}
     {% if is_incremental() %}
-        where _loaded_at >= timestamp_sub(
+        where _loaded_at >= timestamp_sub(  -- noqa: RF02
             (select max(_loaded_at) from {{ this }}),
             interval 36 hour
         )


### PR DESCRIPTION
## Summary
- Fixes a silent data-loss bug in `int_events_normalized` where the 36-hour incremental window was anchored to `current_timestamp()` rather than the last processed `_loaded_at`
- Any run gap > 36h would permanently skip events loaded in that window
- Now anchors to `(select max(_loaded_at) from {{ this }})` — data-relative, safe for any run frequency
- Updated `CLAUDE.md` and doc block to document the correct anchor

## Test plan
- [ ] `dbt compile --select int_events_normalized` — verify rendered SQL uses the subquery anchor
- [ ] Inspect `target/compiled/b2b_saas_dbt/models/intermediate/product/int_events_normalized.sql`
- [ ] `dbt build --select int_events_normalized --exclude package:dbt_project_evaluator` on dev