### PR TITLE
fix: correct MRR reconciliation join and scope events row count

### DIFF
--- a/tests/reconciliation/reconciliation_int_events_normalized_row_count.sql
+++ b/tests/reconciliation/reconciliation_int_events_normalized_row_count.sql
@@ -5,14 +5,22 @@
 {{ config(
     severity='error',
     tags=['data_quality'],
-    description='Validates dedup removed ~0.5% duplicate events, not more than 1%'
+    description='Validates dedup removed ~0.5% of events (not >1%) within the last 30 days. Historical dedup beyond this window is not tested — accepted trade-off for CI scan cost.'
 ) }}
 
 with counts as (
 
     select
-        (select count(*) from {{ ref('stg_funnel__events') }}) as staging_count,
-        (select count(*) from {{ ref('int_events_normalized') }}) as normalized_count
+        (
+            select count(*)
+            from {{ ref('stg_funnel__events') }}
+            where _loaded_at >= timestamp_sub(current_timestamp(), interval 30 day)
+        ) as staging_count,
+        (
+            select count(*)
+            from {{ ref('int_events_normalized') }}
+            where _loaded_at >= timestamp_sub(current_timestamp(), interval 30 day)
+        ) as normalized_count
 
 )
 

--- a/tests/reconciliation/reconciliation_int_mrr_movements_net_mrr.sql
+++ b/tests/reconciliation/reconciliation_int_mrr_movements_net_mrr.sql
@@ -44,11 +44,16 @@ latest_mrr_per_account as (
 )
 
 select
-    m.account_id,
+    coalesce(m.account_id, l.account_id) as account_id,
     m.total_mrr_delta,
     l.final_mrr,
-    abs(m.total_mrr_delta - l.final_mrr) as difference
+    abs(coalesce(m.total_mrr_delta, 0) - coalesce(l.final_mrr, 0)) as difference
 from movements_total as m
-inner join latest_mrr_per_account as l
+full outer join latest_mrr_per_account as l
     on m.account_id = l.account_id
-where abs(m.total_mrr_delta - l.final_mrr) > 0.01
+where
+    abs(coalesce(m.total_mrr_delta, 0) - coalesce(l.final_mrr, 0)) > 0.01
+    -- accounts in lifecycle but no movements (e.g. trial-only with no MRR events)
+    or (m.account_id is null and l.final_mrr > 0)
+    -- accounts with movements but no lifecycle row (e.g. fully churned); zero delta is acceptable
+    or (l.account_id is null and coalesce(m.total_mrr_delta, 0) <> 0)


### PR DESCRIPTION
## Summary
- Change MRR reconciliation test from INNER JOIN to FULL OUTER JOIN — catches churned accounts that were silently excluded
- Scope events row count test to last 30 days via `_loaded_at` filter (~97% scan cost reduction)
- Trade-off: historical dedup regressions beyond 30 days are no longer caught (acceptable for synthetic data)

## Test plan
- [ ] `dbt test --select reconciliation_int_mrr_movements_net_mrr reconciliation_int_events_normalized_row_count`
- [ ] Review compiled SQL in `target/compiled/` for correct FULL OUTER JOIN syntax

Closes #66