### PR TITLE
fix: tighten branch protection and CI enforcement

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,7 +45,7 @@ jobs:
         run: scripts/lint-model-names.sh
 
       - name: Lint doc blocks
-        run: bash scripts/lint-doc-blocks.sh
+        run: bash scripts/lint-doc-blocks.sh --strict
 
   build-and-validate:
     name: Build & Validate

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -50,7 +50,7 @@ repos:
       - id: lint-doc-blocks
         name: lint doc blocks
         language: script
-        entry: scripts/lint-doc-blocks.sh
+        entry: scripts/lint-doc-blocks.sh --strict
         stages: [pre-commit]
 
       - id: tdd-gate

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,4 +1,5 @@
 # b2b-saas-dbt — Architecture Contract
+<!-- CLAUDE.md and AGENTS.md must stay in sync — update both files together -->
 
 ## Project
 Full-company analytics platform for a B2B SaaS company. dbt on BigQuery, Kimball star schema.

--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -92,8 +92,8 @@ models:
           +severity: warn
       governance:
         fct_public_models_without_contract:
-          +enabled: false
+          +enabled: false  # disabled: all public models use access:protected; no public access configured yet
         fct_undocumented_public_models:
-          +enabled: false
+          +enabled: false  # disabled: same reason as above — no public access layer
         fct_exposures_dependent_on_private_models:
-          +enabled: false
+          +enabled: false  # disabled: no exposures defined yet

--- a/scripts/configure-github.sh
+++ b/scripts/configure-github.sh
@@ -18,6 +18,8 @@ gh api repos/"$REPO" \
   --silent
 
 echo "Configuring branch protection on main..."
+# Break-glass: if CI is broken and you need to push a fix, temporarily
+# re-run this script with "enforce_admins": false, push the fix, then re-run with true.
 gh api repos/"$REPO"/branches/main/protection \
   --method PUT \
   --input - <<'JSON'
@@ -26,7 +28,7 @@ gh api repos/"$REPO"/branches/main/protection \
     "strict": false,
     "contexts": ["Lint", "Build & Validate"]
   },
-  "enforce_admins": false,
+  "enforce_admins": true,
   "required_pull_request_reviews": {
     "required_approving_review_count": 0
   },

--- a/scripts/lint-doc-blocks.sh
+++ b/scripts/lint-doc-blocks.sh
@@ -17,7 +17,7 @@ set -euo pipefail
 #   bash scripts/lint-doc-blocks.sh           # warnings for sources/seeds inline
 #   bash scripts/lint-doc-blocks.sh --strict  # all checks are errors
 #
-# Enable --strict once PR #51 lands (fixes inline descriptions in sources/seeds).
+# --strict is now enabled in CI and pre-commit (PR #51 landed, inline descriptions fixed).
 
 STRICT=false
 for arg in "$@"; do

--- a/scripts/secret-scan.sh
+++ b/scripts/secret-scan.sh
@@ -29,7 +29,7 @@ for file in $STAGED; do
     done
 done
 
-_SECRET_CORE='\b(api_key|secret_key|password|token|sessionid|private_key|client_secret)\s*[=:]\s*'
+_SECRET_CORE='(api_key|secret_key|password|token|sessionid|private_key|client_secret)[[:space:]]*[=:][[:space:]]*'
 if git diff --cached -U0 | grep -iE "${_SECRET_CORE}[\"'][A-Za-z0-9+/=_.-]{8,}" >/dev/null 2>&1; then
     echo "BLOCKED: staged diff contains potential secret"
     exit 1


### PR DESCRIPTION
## Summary
- Set `enforce_admins: true` in branch protection with break-glass instructions
- Enable `--strict` on lint-doc-blocks.sh in both CI and pre-commit
- Replace non-POSIX regex shorthands in secret-scan.sh with POSIX equivalents
- Add rationale comments to disabled dbt-project-evaluator governance checks
- Add sync reminders between CLAUDE.md and AGENTS.md

## Test plan
- [ ] `bash scripts/lint-doc-blocks.sh --strict` passes locally
- [ ] `bash scripts/secret-scan.sh` passes with POSIX regex
- [ ] `dbt parse` confirms no YAML syntax errors

Closes #65