### PR TITLE
docs: add inline comments for locked business logic constants

### DIFF
--- a/models/intermediate/cross_domain/int_account_health.sql
+++ b/models/intermediate/cross_domain/int_account_health.sql
@@ -29,6 +29,7 @@ billing as (
         max(event_time) as last_billing_event
     from {{ ref('int_subscription_lifecycle') }}
     where
+        -- 28-day trailing billing window for health score
         event_time >= timestamp_sub(
             current_timestamp(), interval 28 day
         )
@@ -49,6 +50,7 @@ support as (
         ) as avg_resolution_hours
     from {{ ref('int_ticket_metrics') }}
     where
+        -- 28-day trailing support window for health score
         created_at >= timestamp_sub(
             current_timestamp(), interval 28 day
         )
@@ -107,7 +109,7 @@ select
     account_id,
     greatest(0, least(
         100,
-        -- Locked: health weights 0.4/0.3/0.3 activity/billing/support (see decisions.md)
+        -- Locked: health weights 0.4/0.3/0.3 activity/billing/support (see decisions.md PR #37)
         0.4 * activity_score + 0.3 * billing_score + 0.3 * support_score
     )) as health_score,
     activity_score,

--- a/models/intermediate/cross_domain/int_account_health.sql
+++ b/models/intermediate/cross_domain/int_account_health.sql
@@ -13,6 +13,7 @@ with activity as (
                 m.valid_to, timestamp('9999-12-31')
             )
     where
+        -- 28-day trailing activity window for health score
         s.session_start_at >= timestamp_sub(
             current_timestamp(), interval 28 day
         )
@@ -106,6 +107,7 @@ select
     account_id,
     greatest(0, least(
         100,
+        -- Locked: health weights 0.4/0.3/0.3 activity/billing/support (see decisions.md)
         0.4 * activity_score + 0.3 * billing_score + 0.3 * support_score
     )) as health_score,
     activity_score,

--- a/models/intermediate/cross_domain/int_attribution.sql
+++ b/models/intermediate/cross_domain/int_attribution.sql
@@ -46,6 +46,7 @@ attribution_window as (
         on e.resolved_user_id = a.resolved_user_id
     where
         e.event_time < a.activation_at
+        -- Locked: 30-day pre-activation window (see decisions.md PR #35)
         and e.event_time >= timestamp_sub(
             a.activation_at, interval 30 day
         )

--- a/models/intermediate/engagement/int_engagement_states.sql
+++ b/models/intermediate/engagement/int_engagement_states.sql
@@ -83,6 +83,7 @@ classified as (
         la.last_activity_at,
         a.activation_at,
         case
+            -- Sentinel: users with no activity are measured from project start (2024-01-01)
             when la.last_activity_at is null
                 then date_diff(
                     la.snapshot_week_start, date('2024-01-01'), day

--- a/models/intermediate/product/int_sessions.sql
+++ b/models/intermediate/product/int_sessions.sql
@@ -36,6 +36,7 @@ session_boundaries as (
             case
                 when prev_event_time is null
                     then 1
+                -- Locked: 30-min inactivity = new session (see decisions.md PR #35)
                 when
                     timestamp_diff(
                         event_time, prev_event_time, second


### PR DESCRIPTION
## Summary
- Add locked-decision comments linking to decisions.md for: session timeout (1800s), attribution window (30d), health score weights (0.4/0.3/0.3), health trailing window (28d), engagement sentinel date (2024-01-01)
- No logic changes — comments only

## Test plan
- [ ] `dbt parse` confirms no SQL syntax errors from comment additions
- [ ] Visual review: comments match surrounding indentation

Closes #67