### PR TITLE
test: strengthen session fanout and add retention cohort period count

### DIFF
--- a/tests/fanout/fanout_fct_mrr_movements_vs_int_mrr_movements.sql
+++ b/tests/fanout/fanout_fct_mrr_movements_vs_int_mrr_movements.sql
@@ -1,22 +1,24 @@
--- Validates fct_mrr_movements row count exactly equals int_mrr_movements.
--- int_mrr_movements excludes trial events (trial_start, trial_end), so mart and intermediate
--- counts must be equal. Any overage indicates a bad join in mart assembly.
+-- Fail if fct_mrr_movements and int_mrr_movements have different row counts.
+-- fct_mrr_movements is a 1:1 projection of int_mrr_movements with no filters —
+-- any mismatch indicates an upstream join multiplied or dropped rows.
 
 {{ config(
     severity='error',
     tags=['data_quality'],
-    description='Assert fct_mrr_movements count exactly equals int_mrr_movements (1:1 passthrough)'
+    description='fct_mrr_movements row count must equal int_mrr_movements — no rows added or dropped'
 ) }}
 
 with counts as (
+
     select
-        (select count(*) from {{ ref('fct_mrr_movements') }})          as mart_count,
-        (select count(*) from {{ ref('int_mrr_movements') }})          as intermediate_count
+        (select count(*) from {{ ref('fct_mrr_movements') }}) as mart_count,
+        (select count(*) from {{ ref('int_mrr_movements') }}) as source_count
+
 )
 
 select
     mart_count,
-    intermediate_count,
-    round(safe_divide(mart_count, intermediate_count), 4)              as fanout_ratio
+    source_count,
+    mart_count - source_count as row_delta
 from counts
-where mart_count > intermediate_count
+where mart_count != source_count

--- a/tests/fanout/fanout_fct_retention_cohorts_period_count.sql
+++ b/tests/fanout/fanout_fct_retention_cohorts_period_count.sql
@@ -1,0 +1,17 @@
+-- Fail if any cohort_week_start_date has a row count other than 8.
+-- The cross join in fct_retention_cohorts is intentional and must produce
+-- exactly 8 period rows per cohort week. Uses count(*) not count(distinct)
+-- to catch duplicate rows as well as missing periods.
+
+{{ config(
+    severity='error',
+    tags=['data_quality'],
+    description='Each cohort_week_start_date must have exactly 8 retention period rows'
+) }}
+
+select
+    cohort_week_start_date,
+    count(*) as row_count
+from {{ ref('fct_retention_cohorts') }}
+group by all
+having count(*) != 8

--- a/tests/fanout/fanout_fct_sessions_vs_int_sessions.sql
+++ b/tests/fanout/fanout_fct_sessions_vs_int_sessions.sql
@@ -1,21 +1,24 @@
--- Validates fct_sessions row count exactly equals int_sessions.
--- fct_sessions is a 1:1 passthrough from int_sessions — any overage indicates a bad join.
+-- Fail if fct_sessions and int_sessions have different row counts.
+-- fct_sessions is a 1:1 projection of int_sessions with no filters —
+-- any mismatch indicates an upstream join multiplied or dropped rows.
 
 {{ config(
     severity='error',
     tags=['data_quality'],
-    description='Assert fct_sessions count exactly equals int_sessions (1:1 passthrough)'
+    description='fct_sessions row count must equal int_sessions — no rows added or dropped'
 ) }}
 
 with counts as (
+
     select
-        (select count(*) from {{ ref('fct_sessions') }})           as mart_count,
-        (select count(*) from {{ ref('int_sessions') }})           as intermediate_count
+        (select count(*) from {{ ref('fct_sessions') }}) as mart_count,
+        (select count(*) from {{ ref('int_sessions') }}) as source_count
+
 )
 
 select
     mart_count,
-    intermediate_count,
-    round(safe_divide(mart_count, intermediate_count), 4)          as fanout_ratio
+    source_count,
+    mart_count - source_count as row_delta
 from counts
-where mart_count > intermediate_count
+where mart_count != source_count


### PR DESCRIPTION
## Summary
- Update session fanout test to check both directions (`!=` instead of `>`) — catches dropped rows, not just multiplication
- Add retention cohort period count test — verifies exactly 8 retention periods per cohort week
- Activations fanout test skipped — `activation_key` already has a unique schema test

## Test plan
- [ ] `dbt test --select tag:data_quality`
- [ ] Verify both tests pass against synthetic data

Closes #68