### PR TITLE
refactor: parameterise locked business rule constants as dbt vars

### DIFF
--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -24,6 +24,13 @@ vars:
   marts_prefixes: ['fct_', 'dim_', 'bridge_']
   other_prefixes: ['agg_', 'rpt_', 'mart_']
 
+  # Locked business rule constants — change requires decisions.md entry
+  session_timeout_seconds: 1800        # 30-min inactivity threshold (PR #35)
+  attribution_lookback_days: 30        # pre-activation attribution window (PR #35)
+  account_health_trailing_days: 28     # trailing window for health score calculation
+  engagement_active_threshold_days: 14  # days since activity = active state
+  engagement_dormant_threshold_days: 42 # days since activity = dormant state
+
 seeds:
   b2b_saas_dbt:
     +persist_docs:

--- a/models/intermediate/cross_domain/int_account_health.sql
+++ b/models/intermediate/cross_domain/int_account_health.sql
@@ -15,7 +15,7 @@ with activity as (
     where
         -- 28-day trailing activity window for health score
         s.session_start_at >= timestamp_sub(
-            current_timestamp(), interval 28 day
+            current_timestamp(), interval {{ var('account_health_trailing_days') }} day
         )
     group by all
 
@@ -31,7 +31,7 @@ billing as (
     where
         -- 28-day trailing billing window for health score
         event_time >= timestamp_sub(
-            current_timestamp(), interval 28 day
+            current_timestamp(), interval {{ var('account_health_trailing_days') }} day
         )
     group by all
 
@@ -52,7 +52,7 @@ support as (
     where
         -- 28-day trailing support window for health score
         created_at >= timestamp_sub(
-            current_timestamp(), interval 28 day
+            current_timestamp(), interval {{ var('account_health_trailing_days') }} day
         )
     group by all
 
@@ -116,5 +116,5 @@ select
     billing_score,
     support_score,
     current_timestamp() as calculated_at,
-    28 as trailing_window_days
+    {{ var('account_health_trailing_days') }} as trailing_window_days
 from scored

--- a/models/intermediate/cross_domain/int_attribution.sql
+++ b/models/intermediate/cross_domain/int_attribution.sql
@@ -48,7 +48,7 @@ attribution_window as (
         e.event_time < a.activation_at
         -- Locked: 30-day pre-activation window (see decisions.md PR #35)
         and e.event_time >= timestamp_sub(
-            a.activation_at, interval 30 day
+            a.activation_at, interval {{ var('attribution_lookback_days') }} day
         )
 
 ),

--- a/models/intermediate/engagement/int_engagement_states.sql
+++ b/models/intermediate/engagement/int_engagement_states.sql
@@ -103,13 +103,13 @@ classified as (
                 la.last_activity_at is not null
                 and date_diff(
                     la.snapshot_week_start, date(la.last_activity_at), day
-                ) <= 14
+                ) <= {{ var('engagement_active_threshold_days') }}
                 then 'active'
             when
                 la.last_activity_at is not null
                 and date_diff(
                     la.snapshot_week_start, date(la.last_activity_at), day
-                ) <= 42
+                ) <= {{ var('engagement_dormant_threshold_days') }}
                 then 'dormant'
             else 'disengaged'
         end as engagement_state,
@@ -127,7 +127,7 @@ classified as (
                         la.snapshot_week_start,
                         date(la.last_activity_at),
                         day
-                    ) <= 14
+                    ) <= {{ var('engagement_active_threshold_days') }}
                     then 'active'
                 when
                     la.last_activity_at is not null
@@ -135,7 +135,7 @@ classified as (
                         la.snapshot_week_start,
                         date(la.last_activity_at),
                         day
-                    ) <= 42
+                    ) <= {{ var('engagement_dormant_threshold_days') }}
                     then 'dormant'
                 else 'disengaged'
             end

--- a/models/intermediate/product/int_sessions.sql
+++ b/models/intermediate/product/int_sessions.sql
@@ -40,7 +40,7 @@ session_boundaries as (
                 when
                     timestamp_diff(
                         event_time, prev_event_time, second
-                    ) > 1800
+                    ) > {{ var('session_timeout_seconds') }}
                     then 1
                 else 0
             end

--- a/tests/invariants/invariants_fixture_session_boundary_split.sql
+++ b/tests/invariants/invariants_fixture_session_boundary_split.sql
@@ -27,7 +27,7 @@ session_flags as (
                 event_time,
                 lag(event_time) over (partition by anon_id order by event_time),
                 second
-            ) > 1800 then 1
+            ) > {{ var('session_timeout_seconds') }} then 1
             else 0
         end as is_session_start
     from events


### PR DESCRIPTION
## Summary
- Add 5 locked business rule vars to dbt_project.yml: session_timeout_seconds, attribution_lookback_days, account_health_trailing_days, engagement_active_threshold_days, engagement_dormant_threshold_days
- Replace hardcoded constants with `var()` calls in int_sessions, int_attribution, int_account_health (4 sites), int_engagement_states (4 sites)
- Update fixture test to use var instead of hardcoded 1800
- Health score weights (0.4/0.3/0.3) intentionally NOT parameterised — would need a macro for readability

## Test plan
- [ ] `dbt parse` passes with new vars
- [ ] `dbt compile --select int_sessions int_attribution int_account_health int_engagement_states` — check compiled SQL for correct var resolution
- [ ] Verify all 11 `var()` call sites resolve to their default values

Closes #69