### PR TITLE
chore: remove redundant sync comment from CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,4 @@
 # b2b-saas-dbt — Architecture Contract
-<!-- CLAUDE.md and AGENTS.md must stay in sync — update both files together -->
 
 ## Project
 Full-company analytics platform for a B2B SaaS company. dbt on BigQuery, Kimball star schema.


### PR DESCRIPTION
## Summary
AGENTS.md is a symlink to CLAUDE.md — the "keep in sync" comment added in #72 is redundant. They're always identical by definition.

## Test plan
- [x] `ls -la AGENTS.md` confirms symlink