### PR TITLE
test+ci: repair false-green tests, tighten CI teardown, harden shell gates

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -41,8 +41,6 @@ while read -r LOCAL_REF LOCAL_SHA REMOTE_REF REMOTE_SHA; do
         echo "  git checkout -b feat/your-description" >&2
         echo "  git push -u origin HEAD" >&2
         echo "  gh pr create" >&2
-        echo "" >&2
-        echo "See: ~/Agentic/frameworks/engineering/GIT_BRANCH_WORKFLOW.md" >&2
         exit 1
     fi
 done

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,8 +35,8 @@ jobs:
           cache: 'pip'
           cache-dependency-path: requirements-ci.txt
 
-      - name: Install sqlfluff
-        run: pip install sqlfluff
+      - name: Install Python dependencies
+        run: pip install -r requirements-ci.txt
 
       - name: SQLFluff lint
         run: sqlfluff lint models/ --templater jinja
@@ -46,6 +46,13 @@ jobs:
 
       - name: Lint doc blocks
         run: bash scripts/lint-doc-blocks.sh --strict
+
+      - name: Shell script tests
+        run: |
+          for t in scripts/tests/*.sh; do
+            echo "--- $t ---"
+            bash "$t"
+          done
 
   build-and-validate:
     name: Build & Validate
@@ -63,14 +70,14 @@ jobs:
           cache: 'pip'
           cache-dependency-path: requirements-ci.txt
 
-      - name: Install dbt
-        run: pip install dbt-core dbt-bigquery
+      - name: Install Python dependencies
+        run: pip install -r requirements-ci.txt
 
       - name: Cache dbt packages
         uses: actions/cache@v4
         with:
           path: dbt_packages
-          key: dbt-packages-${{ hashFiles('packages.yml') }}
+          key: dbt-packages-${{ hashFiles('package-lock.yml') }}
 
       - name: Install dbt packages
         run: dbt deps
@@ -89,9 +96,6 @@ jobs:
       - name: Check source freshness
         run: dbt source freshness --target ci
         continue-on-error: true  # synthetic data is always stale; documents pattern without blocking CI
-
-      - name: Build staging layer
-        run: dbt build --select models/staging/ --exclude test_type:singular --target ci --full-refresh
 
       - name: Build all models and run tests
         run: dbt build --target ci --full-refresh
@@ -120,6 +124,7 @@ jobs:
             "analytics_ci_${PR_NUMBER}" \
             "analytics_ci_${PR_NUMBER}_staging" \
             "analytics_ci_${PR_NUMBER}_intermediate" \
-            "analytics_ci_${PR_NUMBER}_marts"; do
+            "analytics_ci_${PR_NUMBER}_marts" \
+            "analytics_ci_${PR_NUMBER}_fixtures"; do
             bq rm -r -f --project_id="${GCP_PROJECT_ID}" "${dataset}" || true
           done

--- a/.github/workflows/pr-teardown.yml
+++ b/.github/workflows/pr-teardown.yml
@@ -32,7 +32,8 @@ jobs:
         uses: google-github-actions/setup-gcloud@v2
 
       # Dataset list must stay in sync with dbt_project.yml +schema values
-      # (staging, intermediate, marts) plus the base dataset (evaluator tables).
+      # (staging, intermediate, marts, fixtures) plus the base dataset
+      # (evaluator tables).
       - name: Drop CI datasets for this PR
         env:
           PR_NUMBER: ${{ github.event.pull_request.number }}
@@ -41,7 +42,8 @@ jobs:
             "analytics_ci_${PR_NUMBER}" \
             "analytics_ci_${PR_NUMBER}_staging" \
             "analytics_ci_${PR_NUMBER}_intermediate" \
-            "analytics_ci_${PR_NUMBER}_marts"; do
+            "analytics_ci_${PR_NUMBER}_marts" \
+            "analytics_ci_${PR_NUMBER}_fixtures"; do
             echo "Dropping ${dataset} (if exists)..."
             bq rm -r -f --project_id="${GCP_PROJECT_ID}" "${dataset}" || true
           done

--- a/.sqlfluff
+++ b/.sqlfluff
@@ -8,6 +8,9 @@ indent_unit = space
 # RF04: keywords as identifiers — BigQuery has many reserved-word identifiers
 exclude_rules = AM04, ST06, RF04
 
+[sqlfluff:templater:jinja]
+load_macros_from_path = macros
+
 [sqlfluff:indentation]
 tab_space_size = 4
 

--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -31,6 +31,11 @@ vars:
   engagement_active_threshold_days: 14  # days since activity = active state
   engagement_dormant_threshold_days: 42 # days since activity = dormant state
 
+  # Reconciliation window for the staging→intermediate dedup rate check.
+  # Distinct from the model's incremental lookback (late-arrival dedup): this
+  # is only the slice of history the CI reconciliation test scans.
+  reconciliation_dedup_test_window_days: 30
+
 seeds:
   b2b_saas_dbt:
     +persist_docs:

--- a/decisions.md
+++ b/decisions.md
@@ -141,3 +141,14 @@
 **PR:** #57
 **Why:** CI was not alerting on stale source data or complete data drops in staging
 **What changed:** `dbt source freshness` added as a CI step; `assert_staging_events_min_volume` singular test guards against empty staging loads
+
+## 2026-04-05: Test-harness repair + CI guardrails
+**PR:** #79-linked
+**Why:** Several safety nets did not test what they claimed. The reconciliation dedup-rate test false-greened on an empty sample window (divide-by-zero → null → dropped by WHERE). Fixture dedup tests re-implemented `int_events_normalized`'s partition/order expression inline, so a change to the real model's dedup logic would not be caught. CI was not tearing down the `_fixtures` dataset, cache key referenced the wrong packages file, and pip installs were not using the pinned requirements file. Shell gates used `--diff-filter=ACM`, missing rename-based bypasses, and word-split on filenames with spaces.
+**What changed:**
+- Reconciliation test now fails when `staging_count = 0` and uses a dedicated `reconciliation_dedup_test_window_days` var (separate from the model's 36h incremental lookback).
+- Added `dedup_events_row_number()` macro — `int_events_normalized` and all fixture dedup tests now share a single canonical expression.
+- Added `invariants_stg_billing_cancellation_mrr_zero` to encode the hidden assumption that `int_mrr_movements` churn math depends on.
+- CI now installs from `requirements-ci.txt`, caches off `package-lock.yml`, tears down the `_fixtures` dataset, and drops the duplicate staging build.
+- `secret-scan.sh` and `tdd-gate.sh` switched to `--diff-filter=ACMR` and NUL-safe line iteration.
+- Added shell test harness under `scripts/tests/` wired into CI.

--- a/macros/dedup_events_row_number.sql
+++ b/macros/dedup_events_row_number.sql
@@ -1,0 +1,6 @@
+{% macro dedup_events_row_number() -%}
+    row_number() over (
+        partition by event_id
+        order by _loaded_at asc, ingest_time asc
+    )
+{%- endmacro %}

--- a/models/intermediate/product/int_events_normalized.sql
+++ b/models/intermediate/product/int_events_normalized.sql
@@ -35,10 +35,7 @@ with source as (
         member_role,
         member_reason,
         experiment_flags,
-        row_number() over (
-            partition by event_id
-            order by _loaded_at asc, ingest_time asc
-        ) as _dedup_row_num
+        {{ dedup_events_row_number() }} as _dedup_row_num
     from {{ ref('stg_funnel__events') }} as stg
     {% if is_incremental() %}
         where stg._loaded_at >= timestamp_sub(

--- a/scripts/secret-scan.sh
+++ b/scripts/secret-scan.sh
@@ -18,16 +18,15 @@ BLOCKED_PATTERNS=(
     'service.account\.json$'
 )
 
-STAGED=$(git diff --cached --name-only --diff-filter=ACM)
-
-for file in $STAGED; do
+while IFS= read -r file; do
+    [[ -z "$file" ]] && continue
     for pattern in "${BLOCKED_PATTERNS[@]}"; do
         if echo "$file" | grep -qE -- "$pattern"; then
             echo "BLOCKED: $file matches blocked pattern '$pattern'"
             exit 1
         fi
     done
-done
+done < <(git diff --cached --name-only --diff-filter=ACMR)
 
 _SECRET_CORE='(api_key|secret_key|password|token|sessionid|private_key|client_secret)[[:space:]]*[=:][[:space:]]*'
 if git diff --cached -U0 | grep -iE "${_SECRET_CORE}[\"'][A-Za-z0-9+/=_.-]{8,}" >/dev/null 2>&1; then

--- a/scripts/tdd-gate.sh
+++ b/scripts/tdd-gate.sh
@@ -8,12 +8,12 @@ if [[ "${TDD_BYPASS:-0}" == "1" ]]; then
     exit 0
 fi
 
-STAGED=$(git diff --cached --name-only --diff-filter=ACM)
+STAGED=$(git diff --cached --name-only --diff-filter=ACMR)
 
 # Exempt: docs, dbt files (sql/yml/yaml), config, macros, seeds, CI, hooks, scripts
 # dbt model changes are validated by dbt schema tests, not Python unit tests
-NON_TEST_CHANGES=$(echo "$STAGED" | grep -E -v '(^tests/|(^|/)test_.*\.py$|_test\.py$|\.md$|\.sql$|\.yml$|\.yaml$|^docs/|^\.github/|^\.githooks/|^macros/|^seeds/|^analyses/|^scripts/|^AGENTS\.md$|^CLAUDE\.md$|^decisions\.md$|^llms\.txt$|^\.gitignore$|^\.sqlfluff|^\.pre-commit|^LICENSE$)' || true)
-TEST_CHANGES=$(echo "$STAGED" | grep -E '(^tests/|(^|/)test_.*\.py$|_test\.py$)' || true)
+NON_TEST_CHANGES=$(printf '%s\n' "$STAGED" | grep -E -v '(^tests/|(^|/)test_.*\.py$|_test\.py$|\.md$|\.sql$|\.yml$|\.yaml$|^docs/|^\.github/|^\.githooks/|^macros/|^seeds/|^analyses/|^scripts/|^AGENTS\.md$|^CLAUDE\.md$|^decisions\.md$|^llms\.txt$|^\.gitignore$|^\.sqlfluff|^\.pre-commit|^LICENSE$)' || true)
+TEST_CHANGES=$(printf '%s\n' "$STAGED" | grep -E '(^tests/|(^|/)test_.*\.py$|_test\.py$)' || true)
 
 if [[ -n "$NON_TEST_CHANGES" && -z "$TEST_CHANGES" ]]; then
     echo "BLOCKED: TDD gate failed — code changes require test changes in the same commit."

--- a/scripts/tests/test_secret_scan_catches_renamed_secret.sh
+++ b/scripts/tests/test_secret_scan_catches_renamed_secret.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+# Test: secret-scan.sh blocks when a benign file is renamed to a blocked pattern.
+# A rename is represented in `git diff --cached --name-only` differently depending
+# on --diff-filter. The script should surface the renamed destination path.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SECRET_SCAN="$SCRIPT_DIR/../secret-scan.sh"
+
+TMPDIR_TEST=$(mktemp -d)
+trap 'rm -rf "$TMPDIR_TEST"' EXIT
+
+cd "$TMPDIR_TEST"
+git init --quiet --initial-branch=main
+git config user.email "test@example.com"
+git config user.name "Test"
+
+echo "notes" > notes.txt
+git add notes.txt
+git commit --quiet -m "seed"
+
+# Rename benign file to a blocked pattern (.env)
+git mv notes.txt .env.local
+
+# secret-scan.sh must block this rename
+set +e
+output=$(bash "$SECRET_SCAN" 2>&1)
+exit_code=$?
+set -e
+
+if [[ $exit_code -eq 0 ]]; then
+    echo "FAIL: secret-scan.sh did not block a rename to .env.local"
+    echo "Output: $output"
+    exit 1
+fi
+
+if ! echo "$output" | grep -q "BLOCKED"; then
+    echo "FAIL: output did not contain BLOCKED marker"
+    echo "Output: $output"
+    exit 1
+fi
+
+echo "PASS: renamed secret file is blocked"

--- a/scripts/tests/test_secret_scan_handles_spaces_in_filename.sh
+++ b/scripts/tests/test_secret_scan_handles_spaces_in_filename.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+# Test: secret-scan.sh does not word-split on filenames containing spaces.
+# Previous implementation used `for file in $STAGED` which splits on whitespace,
+# corrupting filenames like "my notes.txt" into two separate "files".
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SECRET_SCAN="$SCRIPT_DIR/../secret-scan.sh"
+
+TMPDIR_TEST=$(mktemp -d)
+trap 'rm -rf "$TMPDIR_TEST"' EXIT
+
+cd "$TMPDIR_TEST"
+git init --quiet --initial-branch=main
+git config user.email "test@example.com"
+git config user.name "Test"
+
+echo "# placeholder" > "my notes.md"
+git add "my notes.md"
+
+# Non-secret file with spaces should pass cleanly
+set +e
+output=$(bash "$SECRET_SCAN" 2>&1)
+exit_code=$?
+set -e
+
+if [[ $exit_code -ne 0 ]]; then
+    echo "FAIL: secret-scan.sh incorrectly blocked 'my notes.md'"
+    echo "Output: $output"
+    exit 1
+fi
+
+# Now stage a file with spaces that SHOULD be blocked
+git rm --cached "my notes.md" >/dev/null
+rm "my notes.md"
+
+echo "secret" > "bad name.env"
+git add "bad name.env"
+
+set +e
+output=$(bash "$SECRET_SCAN" 2>&1)
+exit_code=$?
+set -e
+
+if [[ $exit_code -eq 0 ]]; then
+    echo "FAIL: secret-scan.sh did not block 'bad name.env'"
+    echo "Output: $output"
+    exit 1
+fi
+
+if ! echo "$output" | grep -q "bad name.env"; then
+    echo "FAIL: output did not reference the full filename with space"
+    echo "Output: $output"
+    exit 1
+fi
+
+echo "PASS: filenames with spaces are handled correctly"

--- a/scripts/tests/test_tdd_gate_catches_renamed_model.sh
+++ b/scripts/tests/test_tdd_gate_catches_renamed_model.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+# Test: tdd-gate.sh is invoked on the correct rename filter.
+# The gate exempts SQL files (.sql$), macros, seeds, etc. — the common scenario
+# we must cover is a rename that drops a .py file from tests/ into an unexempt
+# location. With --diff-filter=ACM the rename target is missed entirely.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+TDD_GATE="$SCRIPT_DIR/../tdd-gate.sh"
+
+TMPDIR_TEST=$(mktemp -d)
+trap 'rm -rf "$TMPDIR_TEST"' EXIT
+
+cd "$TMPDIR_TEST"
+git init --quiet --initial-branch=main
+git config user.email "test@example.com"
+git config user.name "Test"
+
+# Seed: a python module with a corresponding test
+mkdir -p src tests
+cat > src/thing.py <<'EOF'
+def thing():
+    return 1
+EOF
+cat > tests/test_thing.py <<'EOF'
+def test_thing():
+    assert 1 == 1
+EOF
+git add src/thing.py tests/test_thing.py
+git commit --quiet -m "seed"
+
+# Simulate: rename src/thing.py to src/renamed_thing.py with no test change.
+# This is a code change without corresponding test change — gate must block.
+git mv src/thing.py src/renamed_thing.py
+
+set +e
+unset TDD_BYPASS
+output=$(bash "$TDD_GATE" 2>&1)
+exit_code=$?
+set -e
+
+if [[ $exit_code -eq 0 ]]; then
+    echo "FAIL: tdd-gate.sh did not block a renamed code file without test changes"
+    echo "Output: $output"
+    exit 1
+fi
+
+if ! echo "$output" | grep -q "BLOCKED"; then
+    echo "FAIL: output did not contain BLOCKED marker"
+    echo "Output: $output"
+    exit 1
+fi
+
+echo "PASS: rename-only code change is blocked by TDD gate"

--- a/tests/invariants/invariants_fixture_backfill_replay_earliest_wins.sql
+++ b/tests/invariants/invariants_fixture_backfill_replay_earliest_wins.sql
@@ -13,10 +13,7 @@ with deduped as (
     select
         event_id,
         _loaded_at,
-        row_number() over (
-            partition by event_id
-            order by _loaded_at asc, ingest_time asc
-        ) as _dedup_row_num
+        {{ dedup_events_row_number() }} as _dedup_row_num
     from {{ ref('fixture_events_backfill_replay') }}
 
 ),

--- a/tests/invariants/invariants_fixture_duplicates_dedup.sql
+++ b/tests/invariants/invariants_fixture_duplicates_dedup.sql
@@ -13,10 +13,7 @@ with deduped as (
     select
         event_id,
         _loaded_at,
-        row_number() over (
-            partition by event_id
-            order by _loaded_at asc, ingest_time asc
-        ) as _dedup_row_num
+        {{ dedup_events_row_number() }} as _dedup_row_num
     from {{ ref('fixture_events_duplicates') }}
 
 ),

--- a/tests/invariants/invariants_fixture_late_arrivals_dedup.sql
+++ b/tests/invariants/invariants_fixture_late_arrivals_dedup.sql
@@ -1,5 +1,7 @@
 -- Fixture test: late-arriving duplicate (same event_id, _loaded_at 48h apart).
--- Applies the dedup logic from int_events_normalized inline.
+-- Applies the canonical dedup expression from the dedup_events_row_number
+-- macro (also used by int_events_normalized) so this test stays in sync
+-- with the real model's partition/order when the dedup logic evolves.
 -- Expects 0 rows: no event_id should have more than 1 row after deduplication.
 
 {{ config(
@@ -11,10 +13,7 @@
 with deduped as (
     select
         event_id,
-        row_number() over (
-            partition by event_id
-            order by _loaded_at asc, ingest_time asc
-        ) as _dedup_row_num
+        {{ dedup_events_row_number() }} as _dedup_row_num
     from {{ ref('fixture_events_late_arrivals') }}
 )
 

--- a/tests/invariants/invariants_fixture_multi_device_no_duplicate_events.sql
+++ b/tests/invariants/invariants_fixture_multi_device_no_duplicate_events.sql
@@ -12,10 +12,7 @@
 with deduped as (
     select
         event_id,
-        row_number() over (
-            partition by event_id
-            order by _loaded_at asc, ingest_time asc
-        ) as _dedup_row_num
+        {{ dedup_events_row_number() }} as _dedup_row_num
     from {{ ref('fixture_events_multi_device') }}
 ),
 

--- a/tests/invariants/invariants_fixture_out_of_order_no_loss.sql
+++ b/tests/invariants/invariants_fixture_out_of_order_no_loss.sql
@@ -12,10 +12,7 @@
 with deduped as (
     select
         event_id,
-        row_number() over (
-            partition by event_id
-            order by _loaded_at asc, ingest_time asc
-        ) as _dedup_row_num
+        {{ dedup_events_row_number() }} as _dedup_row_num
     from {{ ref('fixture_events_out_of_order') }}
 ),
 

--- a/tests/invariants/invariants_stg_billing_cancellation_mrr_zero.sql
+++ b/tests/invariants/invariants_stg_billing_cancellation_mrr_zero.sql
@@ -1,0 +1,20 @@
+-- Assert cancellation events carry mrr_amount = 0.
+-- int_mrr_movements uses the mrr_amount column directly when computing the
+-- churn component; if a cancellation event ever emits a non-zero mrr_amount
+-- the churn figure will be understated (or negated). The staging contract
+-- enforces not_null and >= 0, but not the cancellation-specific zero, so
+-- this invariant backfills the hidden assumption.
+
+{{ config(
+    severity='error',
+    tags=['data_quality'],
+    description='Assert cancellation subscription events have mrr_amount = 0'
+) }}
+
+select
+    subscription_event_id,
+    event_type,
+    mrr_amount
+from {{ ref('stg_billing__subscriptions') }}
+where event_type = 'cancellation'
+    and mrr_amount != 0

--- a/tests/reconciliation/reconciliation_int_events_normalized_row_count.sql
+++ b/tests/reconciliation/reconciliation_int_events_normalized_row_count.sql
@@ -5,27 +5,31 @@
 {{ config(
     severity='error',
     tags=['data_quality'],
-    description='Validates dedup removed ~0.5% of events (not >1%) within the reconciliation window. Historical dedup beyond this window is not tested — accepted trade-off for CI scan cost. Fails loudly when the window is empty so an idle dataset cannot false-green.'
+    description='Validates dedup removed ~0.5% of events (not >1%) within the reconciliation window. The window is anchored to max(_loaded_at) in staging so the test scans the actual data range rather than wall-clock time — CI datasets built from fixtures with frozen timestamps still exercise the check. Historical dedup beyond the window is not tested — accepted trade-off for CI scan cost. Fails loudly when the window is empty so an idle dataset cannot false-green.'
 ) }}
 
-with counts as (
+with window_anchor as (
+
+    select timestamp_sub(
+        max(_loaded_at),
+        interval {{ var('reconciliation_dedup_test_window_days') }} day
+    ) as cutoff
+    from {{ ref('stg_funnel__events') }}
+
+),
+
+counts as (
 
     select
         (
             select count(*)
             from {{ ref('stg_funnel__events') }}
-            where _loaded_at >= timestamp_sub(
-                current_timestamp(),
-                interval {{ var('reconciliation_dedup_test_window_days') }} day
-            )
+            where _loaded_at >= (select cutoff from window_anchor)
         ) as staging_count,
         (
             select count(*)
             from {{ ref('int_events_normalized') }}
-            where _loaded_at >= timestamp_sub(
-                current_timestamp(),
-                interval {{ var('reconciliation_dedup_test_window_days') }} day
-            )
+            where _loaded_at >= (select cutoff from window_anchor)
         ) as normalized_count
 
 )

--- a/tests/reconciliation/reconciliation_int_events_normalized_row_count.sql
+++ b/tests/reconciliation/reconciliation_int_events_normalized_row_count.sql
@@ -5,7 +5,7 @@
 {{ config(
     severity='error',
     tags=['data_quality'],
-    description='Validates dedup removed ~0.5% of events (not >1%) within the last 30 days. Historical dedup beyond this window is not tested — accepted trade-off for CI scan cost.'
+    description='Validates dedup removed ~0.5% of events (not >1%) within the reconciliation window. Historical dedup beyond this window is not tested — accepted trade-off for CI scan cost. Fails loudly when the window is empty so an idle dataset cannot false-green.'
 ) }}
 
 with counts as (
@@ -14,12 +14,18 @@ with counts as (
         (
             select count(*)
             from {{ ref('stg_funnel__events') }}
-            where _loaded_at >= timestamp_sub(current_timestamp(), interval 30 day)
+            where _loaded_at >= timestamp_sub(
+                current_timestamp(),
+                interval {{ var('reconciliation_dedup_test_window_days') }} day
+            )
         ) as staging_count,
         (
             select count(*)
             from {{ ref('int_events_normalized') }}
-            where _loaded_at >= timestamp_sub(current_timestamp(), interval 30 day)
+            where _loaded_at >= timestamp_sub(
+                current_timestamp(),
+                interval {{ var('reconciliation_dedup_test_window_days') }} day
+            )
         ) as normalized_count
 
 )
@@ -31,5 +37,6 @@ select
         as dedup_rate
 from counts
 where
-    1.0 - (cast(normalized_count as float64) / nullif(staging_count, 0)) > 0.01
+    staging_count = 0
+    or 1.0 - (cast(normalized_count as float64) / nullif(staging_count, 0)) > 0.01
     or normalized_count > staging_count


### PR DESCRIPTION
Closes #79

## Summary

- Reconciliation dedup-rate test no longer false-greens on an empty sample window; moved the 30-day slice into a dedicated `reconciliation_dedup_test_window_days` var so it cannot drift with the model's incremental lookback.
- Added `dedup_events_row_number()` macro; `int_events_normalized` and all five fixture dedup tests now share a single canonical partition/order expression.
- Added `invariants_stg_billing_cancellation_mrr_zero` to encode the hidden assumption `int_mrr_movements` churn math depends on.
- CI installs from `requirements-ci.txt` (pulls in `sqlfluff-templater-dbt`), caches off `package-lock.yml`, tears down the `_fixtures` dataset, and drops the duplicate staging build.
- `secret-scan.sh` and `tdd-gate.sh` use `--diff-filter=ACMR` and null-safe iteration. Removed a private path reference from `.githooks/pre-push`.
- New shell test harness under `scripts/tests/` wired into the lint job.

## Deferred

Three fixture tests (`session_boundary_split`, `stage_skipping_valid`, `stage_regression_no_monotonicity_violation`) still re-implement cross-model business logic (session boundary detection, funnel stage mapping). Fixing these cleanly needs either dbt unit tests or extracting the sessionization/funnel expressions into macros — out of scope here.

## Test plan

- [x] `dbt parse` clean
- [x] `dbt compile` of all touched tests produces the expected SQL
- [x] `scripts/tests/*.sh` all green
- [x] `secret-scan.sh` + `tdd-gate.sh` pass against the staged diff
- [ ] CI: build + tests on per-PR dataset
- [ ] CI: `_fixtures` dataset torn down on PR close