### PR TITLE
docs: add foundation docs (architecture, event/metric contracts, runbook)

### DIFF
--- a/RUNBOOK.md
+++ b/RUNBOOK.md
@@ -1,0 +1,172 @@
+# Runbook
+
+Setup, daily commands, and incident response for `b2b-saas-dbt`.
+
+## Prerequisites
+
+- Python 3.12
+- A BigQuery project (the synthetic dataset costs effectively $0 in the free tier).
+- `gcloud` CLI installed and authenticated:
+  ```
+  gcloud auth login
+  gcloud auth application-default login
+  ```
+
+## First-Time Setup
+
+```bash
+# Clone and enter the repo
+git clone https://github.com/joeljohn07/b2b-saas-dbt.git
+cd b2b-saas-dbt
+
+# Set the GCP project (used by every source declaration)
+export GCP_PROJECT_ID=your-project-id
+
+# Install Python dependencies (CI deps + dev deps)
+python3.12 -m venv .venv
+source .venv/bin/activate
+pip install -r requirements-ci.txt -r requirements-dev.txt
+
+# Install dbt packages
+dbt deps
+
+# Copy the profile template and edit for your GCP project
+cp profiles.yml.example ~/.dbt/profiles.yml
+# Edit ~/.dbt/profiles.yml to set project, dataset, location to taste
+
+# Install pre-commit hooks (sqlfluff, dbt-parse, secret scan, doc-block lint)
+pre-commit install
+```
+
+## Generate the Synthetic Dataset
+
+The project has no real data — the synthetic generator produces a complete, deterministic dataset and uploads it to your BigQuery project.
+
+```bash
+# Local CSV only (fast smoke test)
+python scripts/generate_synthetic_data.py --users 1000 --months 6
+
+# Full 50K-user / 24-month dataset uploaded to BigQuery
+python scripts/generate_synthetic_data.py --users 50000 --months 24 --upload
+```
+
+The upload creates and populates `raw_funnel.events`, `raw_billing.subscriptions`, `raw_billing.invoices`, `raw_marketing.spend`, `raw_support.tickets` in your GCP project. Re-running with the same `--seed` produces byte-identical output.
+
+## Daily Commands
+
+```bash
+# Parse only (fast — catches Jinja and ref errors)
+dbt parse
+
+# Build everything against your dev target
+dbt build --target dev
+
+# Build a slice (intermediate billing onwards)
+dbt build --select +int_mrr_movements+ --target dev
+
+# Run tests only, without rebuilding
+dbt test --target dev
+
+# Serve the docs site locally
+dbt docs generate && dbt docs serve --port 8080
+```
+
+## CI Behaviour
+
+Every PR runs two GitHub Actions workflows:
+
+- `ci.yml` — lint (sqlfluff, model-name lint, doc-block lint, shell tests), then `dbt build --target ci --full-refresh` into a per-PR dataset `analytics_ci_<pr_number>_*`. Authenticates to GCP via OIDC / Workload Identity Federation — no long-lived service-account keys.
+- `pr-teardown.yml` — runs on PR close, drops the per-PR dataset.
+
+CI gates that block merge:
+- sqlfluff lint failure
+- model naming violation (`scripts/lint-model-names.sh`)
+- doc-block lint failure (`scripts/lint-doc-blocks.sh --strict`)
+- shell test failure
+- dbt parse, build, or test failure
+- `dbt-project-evaluator` rule with `severity: error` (DAG boundary violations)
+
+## Pre-Commit Hooks
+
+Run on every commit. To run manually across the whole repo:
+
+```bash
+pre-commit run --all-files
+```
+
+Hooks in order:
+- trailing whitespace, end-of-file, YAML syntax, merge-conflict markers
+- sqlfluff lint (Jinja templater for speed; CI uses the dbt templater for full accuracy)
+- dbt-parse, model-has-tests, model-has-properties, model-has-description
+- doc-block lint
+- secret scan (`scripts/secret-scan.sh`)
+- conventional-commit message check (commit-msg hook)
+- TDD gate on push (`scripts/tdd-gate.sh` — model changes must come with test changes)
+
+## Common Failures
+
+### `dbt parse` fails with `compilation error in model`
+
+Most common cause: a `ref()` to a model that doesn't exist or a `source()` that's not declared in `_sources.yml`. Run `dbt list --select <model>` to confirm dbt sees the model.
+
+### `dbt build` fails with `Permission denied while accessing dataset`
+
+Check that `gcloud auth application-default login` is current and the dataset lives in the location declared in `profiles.yml` (`EU` by default).
+
+### CI fails with `Dataset analytics_ci_<n>_* does not exist`
+
+Race condition between the build job and an earlier teardown. Re-run the failed job — it will create the dataset fresh.
+
+### `dbt-project-evaluator` raises `fct_marts_or_intermediate_dependent_on_source`
+
+A marts or intermediate model is referencing a `source()` directly. Move the reference up one layer: intermediate should only `ref()` staging, marts should only `ref()` intermediate or other marts.
+
+### `farm_fingerprint` returns NULL
+
+Usually a NULL input — `farm_fingerprint(concat(a, '|', b))` returns NULL if either `a` or `b` is NULL. Wrap inputs with `coalesce(..., '')` or, better, guarantee non-null upstream and let the NULL surface as a test failure.
+
+### Incremental `int_events_normalized` missing late events
+
+The 36-hour lookback (`events_incremental_lookback_hours` var) is anchored on `_loaded_at`, not `event_time`. If an event arrives more than 36 hours after the previous run, it will not be picked up by `dbt build` — only by `dbt build --full-refresh`. Bump the var or schedule a periodic full refresh if your source has longer tails.
+
+### Pre-commit hook `secret-scan.sh` flags a commit
+
+The hook looks for high-entropy strings that match common secret formats. Review the flagged file — if it's a false positive (e.g., a UUID literal in a fixture), prefix the line with a `# noqa: secret` comment and re-commit. Never bypass with `--no-verify` unless you've manually verified no secret is leaking.
+
+## Useful Selectors
+
+```bash
+# Everything in one domain
+dbt build --select tag:product
+
+# All marts and their upstream dependencies
+dbt build --select +tag:marts
+
+# Only the changed models in the current branch (state defer)
+dbt build --select state:modified+ --defer --state ./target-base
+
+# Skip a slow incremental during dev
+dbt build --exclude int_events_normalized
+```
+
+## State and Manifests
+
+After a successful build, `target/manifest.json` is the authoritative artifact for that run. On `push to main`, CI uploads it as a workflow artifact for downstream `--defer` builds.
+
+## Where to Look When Something's Wrong
+
+| Symptom | First place to look |
+|---|---|
+| A metric looks wrong | `docs/metric-contract.md` for the canonical definition, then the source model. |
+| A column appeared / disappeared | `decisions.md` (search for the column name). |
+| A test failed and you don't know why | `tests/<dir>/CLAUDE.md` for the test charter, then the test SQL. |
+| CI passed but prod looks off | Compare the failed metric against `tests/reconciliation/` — they're designed to catch exactly this. |
+| dbt won't parse and the error is opaque | `dbt parse --debug` and read the full traceback. |
+
+## See Also
+
+- [`docs/architecture.md`](docs/architecture.md) — system design.
+- [`docs/event-contract.md`](docs/event-contract.md) — source schema.
+- [`docs/metric-contract.md`](docs/metric-contract.md) — canonical metrics.
+- [`docs/quality-gates.md`](docs/quality-gates.md) — test severity policy.
+- [`decisions.md`](decisions.md) — every architectural decision with rationale.

--- a/RUNBOOK.md
+++ b/RUNBOOK.md
@@ -131,7 +131,12 @@ The 36-hour lookback (`events_incremental_lookback_hours` var) is anchored on `_
 
 ### Pre-commit hook `secret-scan.sh` flags a commit
 
-The hook looks for high-entropy strings that match common secret formats. Review the flagged file — if it's a false positive (e.g., a UUID literal in a fixture), prefix the line with a `# noqa: secret` comment and re-commit. Never bypass with `--no-verify` unless you've manually verified no secret is leaking.
+Two failure modes:
+
+1. **Filename pattern match** — paths like `.env`, `*.key`, `*.pem`, `downloads/`, `*-credentials.json`. Move or rename the file (and verify it really shouldn't be committed).
+2. **Content match** — the staged diff contains a quoted value following `api_key`, `secret_key`, `password`, `token`, `sessionid`, `private_key`, or `client_secret`. Review the diff; if a real secret leaked, rotate it. If it's a literal example (fixture, docs example), rephrase the surrounding text so the keyword/value pattern doesn't match — there is no in-line bypass token.
+
+The hook has no allowlist. Never bypass with `--no-verify`.
 
 ## Useful Selectors
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,146 @@
+# Architecture
+
+System design for the `b2b-saas-dbt` analytics platform.
+
+## Goals
+
+A single source of truth for B2B SaaS analytics where business logic is defined exactly once. Five raw source domains feed a Kimball star schema. Every metric that appears in any consumer — dashboard, ad-hoc query, agent answer — resolves back to one definition in this repo.
+
+## Source Domains
+
+| Domain | Raw dataset | Entities |
+|---|---|---|
+| Product / funnel | `raw_funnel` | events |
+| Billing | `raw_billing` | subscription_events, invoices |
+| Marketing | `raw_marketing` | spend |
+| Support | `raw_support` | tickets |
+
+Source contracts are declared in `models/staging/<domain>/_sources.yml` with freshness SLAs on `_loaded_at`.
+
+## Three Layers
+
+```
+raw sources           staging              intermediate            marts
+───────────          ─────────            ──────────────         ─────────
+raw_funnel     ───►  stg_*__events   ───► int_events_normalized ──► fct_sessions
+raw_billing    ───►  stg_*__subs     ───► int_mrr_movements     ──► fct_mrr_movements
+               ───►  stg_*__invoices ───► int_attribution       ──► dim_users
+raw_marketing  ───►  stg_*__spend    ───► int_engagement_states ──► dim_accounts
+raw_support    ───►  stg_*__tickets  ───► int_account_health    ──► dim_date
+
+                     view, 1:1            view (default), logic    table, star schema
+                     contracts enforced   incremental on events    contracts on fct/dim/bridge
+```
+
+### Staging — interface
+
+One model per source table. Renames, casts, JSON shreds. No joins, no aggregations, no derived columns. Materialized as views with `contract.enforced: true`, so any breaking source-schema change fails fast.
+
+Reference: [`docs/layers/layer-contract.md`](layers/layer-contract.md).
+
+### Intermediate — logic
+
+All non-trivial business decisions live here. Each is anchored in one model with one canonical definition:
+
+| Decision | Model | Lookback / window var |
+|---|---|---|
+| Event dedup + late-arrival handling | `int_events_normalized` | `events_incremental_lookback_hours` (36h) |
+| Anonymous→known user stitching | `int_identity_stitched` | `identity_stitching_lookback_days` (90d) |
+| Sessionization | `int_sessions` | `session_timeout_seconds` (1800s) |
+| Marketing attribution | `int_attribution` | `attribution_lookback_days` (30d) |
+| Subscription state machine | `int_subscription_lifecycle` | — |
+| MRR movement classification | `int_mrr_movements` | — |
+| Weekly engagement state | `int_engagement_states` | `engagement_active_threshold_days`, `engagement_dormant_threshold_days` |
+| Account health score | `int_account_health` | `account_health_trailing_days` (28d) |
+| Checkout→subscription conversion | `int_checkout_conversion` | `checkout_conversion_window_days` (30d) |
+
+Every business policy is a project variable, not a hardcoded interval. Changing one of them is a `dbt_project.yml` edit plus a `decisions.md` entry, not a code search.
+
+Materialized as views by default; `int_events_normalized` is the only incremental model. References staging or other intermediate models via `ref()` — never `source()`.
+
+### Marts — consumer surface
+
+Kimball star schema. Three model types carry `contract.enforced: true`:
+
+- **Facts** (`fct_*`): one row per business event or snapshot. Grain declared in model description.
+- **Dimensions** (`dim_*`): one row per entity. SCD Type 1 only — history lives in intermediate snapshot models.
+- **Bridges** (`bridge_*`): one row per many-to-many relationship.
+
+Optional model types (`agg_`, `rpt_`, `mart_`) sit on top of facts and dimensions for query patterns that need pre-aggregation, dashboard-specific denormalization, or dim+fact blends. Contracts on these are opt-in.
+
+Conformed dimensions live in `marts/core/`. Domain-specific dimensions (e.g., `dim_sessions`, `dim_experiments`) live with their domain. All surrogate keys use `farm_fingerprint()` for INT64 hashes — consistent across the star, no UUID strings.
+
+Reference: [`docs/layers/dimensional-modeling-guidelines.md`](layers/dimensional-modeling-guidelines.md).
+
+## Materialization Policy
+
+| Layer | Default | Exception |
+|---|---|---|
+| staging | `view` | — |
+| intermediate | `view` | `int_events_normalized` is `incremental` (merge on `event_id`, 36h lookback on `_loaded_at`) |
+| marts | `table` | — |
+
+Views minimise BigQuery storage cost in dev; tables on marts give stable query performance for downstream consumers.
+
+## DAG Boundaries
+
+Enforced by `dbt-project-evaluator` (rules in `dbt_project.yml`, severity = `error`):
+
+- `fct_*` and `dim_*` never reference staging or source directly.
+- Marts never join to a source.
+- Intermediate is the only layer that can both `ref()` staging and produce inputs for marts.
+
+Violations fail CI.
+
+## Naming
+
+- Staging: `stg_<source>__<entity>` (double underscore separates source from entity).
+- Intermediate: `int_<concept>`, with optional suffixes `_prep` (source-specific rules before union) and `_unioned` (union of multiple sources).
+- Marts: `fct_<event>`, `dim_<entity>`, `bridge_<relationship>`, `agg_<grain>`, `rpt_<consumer>`, `mart_<entity>`.
+
+Subdirectories provide domain context, never role-played in the model name itself.
+
+## Documentation Ownership
+
+Every column description lives once. Authored in `_<scope>__docs.md` files using `{% docs %}` blocks; referenced from `schema.yml` via `{{ doc('col_name') }}`. Pass-through columns reuse the same doc tag across layers; transformed columns get a new doc block authored where the transformation lives.
+
+Reference: [`docs/doc-block-convention.md`](doc-block-convention.md).
+
+## Testing Strategy
+
+Four test directories, each with a clear charter:
+
+- `tests/invariants/` — things that must always be true (e.g., session boundaries don't overlap, retention rates ∈ [0,1]).
+- `tests/reconciliation/` — mart row counts and totals reconcile to upstream intermediate (e.g., `fct_mrr_movements` net = `int_mrr_movements` sum).
+- `tests/fanout/` — guards against unintended grain expansion (e.g., `fct_sessions` row count = `int_sessions` row count).
+- `tests/contracts/` — populated-table assertions for the production marts.
+
+Plus per-column tests in `_models.yml`: `unique`, `not_null`, `accepted_values`, `relationships`, dbt-utils helpers.
+
+Reference: [`docs/quality-gates.md`](quality-gates.md).
+
+## CI
+
+Two workflows in `.github/workflows/`:
+
+- `ci.yml` — runs on every PR: dbt parse, sqlfluff lint, dbt-project-evaluator, full build into a per-PR BigQuery dataset, then `dbt test`. Per-PR dataset isolation prevents cross-PR collision; teardown handled by `pr-teardown.yml` on PR close.
+- `pr-teardown.yml` — drops the per-PR dataset.
+
+CI runs against BigQuery (no DuckDB stand-in). The synthetic dataset is ~50K users × 24 months — large enough to surface incremental-strategy and join-grain bugs.
+
+## Cross-Repo Position
+
+This repo is the data foundation. Two sibling repos (planned, not yet built) consume it:
+
+- `b2b-saas-lightdash` — BI semantic layer over the marts.
+- `analytics-agent` — agentic Q&A over the BigQuery + dbt + Lightdash MCP surfaces.
+
+Marts are the contract surface for both. The dbt semantic layer (not yet enabled) will be the canonical metric definitions.
+
+## See Also
+
+- [`README.md`](../README.md) — the elevator-pitch version of this doc.
+- [`decisions.md`](../decisions.md) — every architectural call with rationale and alternatives considered.
+- [`docs/event-contract.md`](event-contract.md) — exact event schema.
+- [`docs/metric-contract.md`](metric-contract.md) — canonical metric definitions.
+- [`RUNBOOK.md`](../RUNBOOK.md) — setup, build, and incident response.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -102,7 +102,7 @@ Subdirectories provide domain context, never role-played in the model name itsel
 
 ## Documentation Ownership
 
-Every column description lives once. Authored in `_<scope>__docs.md` files using `{% docs %}` blocks; referenced from `schema.yml` via `{{ doc('col_name') }}`. Pass-through columns reuse the same doc tag across layers; transformed columns get a new doc block authored where the transformation lives.
+Every column description lives once. Authored in `_<scope>__docs.md` files using dbt's `docs` Jinja blocks; referenced from `schema.yml` via the `doc(...)` macro. Pass-through columns reuse the same doc tag across layers; transformed columns get a new doc block authored where the transformation lives.
 
 Reference: [`docs/doc-block-convention.md`](doc-block-convention.md).
 

--- a/docs/event-contract.md
+++ b/docs/event-contract.md
@@ -1,0 +1,169 @@
+# Event Contract
+
+Schema, types, and semantics for events flowing into this project. The contract is enforced in the staging layer via dbt model contracts (`contract.enforced: true`), so any drift in a source surface fails the build.
+
+## Sources
+
+Five raw tables across four BigQuery datasets feed the staging layer. All carry `_loaded_at` for ingestion-time tracking and dbt source freshness (warn 24h, error 48h).
+
+| Dataset | Table | Grain | Volume (synthetic) |
+|---|---|---|---|
+| `raw_funnel` | `events` | one row per product event | ~5.5M / 24mo / 50K users |
+| `raw_billing` | `subscriptions` | one row per subscription event | ~150K |
+| `raw_billing` | `invoices` | one row per invoice | ~200K |
+| `raw_marketing` | `spend` | one row per channel × day | ~30K |
+| `raw_support` | `tickets` | one row per ticket | ~40K |
+
+## `raw_funnel.events`
+
+The product event stream. Every user interaction with the application lands here.
+
+### Identifiers
+
+| Field | Type | Nullable | Notes |
+|---|---|---|---|
+| `event_id` | STRING | NO | Stable, unique. Dedup key in `int_events_normalized`. |
+| `user_id` | STRING | YES | NULL for anonymous events (pre-signup). |
+| `anon_id` | STRING | NO | Always present. Stitches to `user_id` via `int_identity_stitched`. |
+| `account_id` | STRING | YES | NULL until the user joins or creates an account. |
+
+### Timestamps
+
+| Field | Type | Semantics |
+|---|---|---|
+| `event_time` | TIMESTAMP | When the event happened, per the client. May be backdated by late delivery. |
+| `ingest_time` | TIMESTAMP | When the collector received the event. |
+| `_loaded_at` | TIMESTAMP | When the row landed in BigQuery. Anchors incremental lookbacks. |
+| `event_date` | DATE | Partition key. Derived from `event_time`. |
+
+**`event_time` vs `_loaded_at`** — `int_events_normalized` is incremental and uses a 36-hour lookback anchored to `_loaded_at`, not `event_time`. A late-arriving event has an old `event_time` but a recent `_loaded_at`; anchoring to `event_time` would miss it entirely. The `events_incremental_lookback_hours` var controls the window.
+
+### Event Classification
+
+| Field | Type | Domain |
+|---|---|---|
+| `event_type` | STRING | See enum below. |
+| `platform` | STRING | `web`, `ios`, `android`, `api`. |
+| `channel` | STRING | First-touch acquisition channel (organic, paid, referral, direct). |
+| `plan_context` | STRING | Plan the user was on when the event fired (free, trial, starter, growth, enterprise). |
+
+#### `event_type` enum
+
+| Value | Phase | Required properties |
+|---|---|---|
+| `page_view` | navigation | `page_url`, `referrer` |
+| `signup` | acquisition | `signup_method` |
+| `activation` | activation | `activation_action`, `time_to_activate_hours` |
+| `feature_use` | engagement | `feature_name`, `duration_seconds` |
+| `paywall_view` | monetization | `source_page` |
+| `upgrade_click` | monetization | `source_page`, `target_plan` |
+| `checkout_start` | monetization | `target_plan`, `billing_cycle` |
+| `member_invited` | team | `role` (invited role) |
+| `member_joined` | team | `role` (joined role) |
+| `member_removed` | team | `reason` |
+
+The `properties` JSON column carries event-specific payloads. The staging model shreds the per-event-type keys into typed columns (`signup_method`, `activation_action`, `feature_name`, etc.); each is NULL when not applicable.
+
+### Marketing Attribution
+
+UTM parameters carried on every event for last-touch attribution. NULL for organic/direct.
+
+| Field | Type |
+|---|---|
+| `utm_source` | STRING |
+| `utm_medium` | STRING |
+| `utm_campaign` | STRING |
+| `utm_term` | STRING |
+| `utm_content` | STRING |
+
+### Device
+
+`device_type`, `browser`, `os`, `user_agent` — all STRING, all nullable.
+
+### Experiments
+
+`experiment_flags` — JSON string holding `{experiment_id: variant_id}` pairs active at event time. Passed through staging unchanged; unnested in `int_experiment_results` and surfaced in `fct_experiment_exposures` / `bridge_user_experiments`.
+
+## `raw_billing.subscriptions`
+
+Subscription state-change events. One row per change.
+
+| Field | Type | Notes |
+|---|---|---|
+| `subscription_event_id` | STRING | PK. |
+| `subscription_id` | STRING | Stable across the lifetime of a subscription. |
+| `user_id` | STRING | Buyer of record. |
+| `account_id` | STRING | Account the subscription belongs to. |
+| `event_type` | STRING | See enum below. |
+| `event_time` | TIMESTAMP | When the change took effect. |
+| `_loaded_at` | TIMESTAMP | Ingestion timestamp. |
+| `plan` | STRING | Plan after the change. |
+| `previous_plan` | STRING | Plan before. NULL on `subscription_start`. |
+| `billing_cycle` | STRING | `monthly` or `annual`. |
+| `mrr_amount` | NUMERIC | Normalized monthly revenue after the change. |
+| `currency` | STRING | ISO 4217. |
+| `cancel_reason` | STRING | NULL except on `cancellation`. |
+| `is_voluntary` | BOOLEAN | NULL except on `cancellation`. |
+
+`event_type` enum: `trial_start`, `trial_end`, `subscription_start`, `renewal`, `upgrade`, `downgrade`, `cancellation`, `reactivation`.
+
+These are not classified into MRR movements at the raw level — that classification (`new`, `expansion`, `contraction`, `churn`, `reactivation`) is the job of `int_mrr_movements` and is the single source of truth for MRR motion.
+
+## `raw_billing.invoices`
+
+One row per invoice issued. `line_items` is passed through as raw JSON (variable-length structure consumed directly by reporting tools) — not shredded in staging.
+
+Key fields: `invoice_id` (PK), `subscription_id`, `account_id`, `issued_at`, `paid_at` (NULL until paid), `refunded_at` (NULL unless refunded), `amount_due`, `amount_paid`, `currency`, `line_items` (JSON).
+
+`is_paid` semantics: `true` iff `paid_at IS NOT NULL AND refunded_at IS NULL`. Refunded invoices count as recognised revenue at the time of payment, not as payment history — i.e., once refunded, `is_paid` flips back to `false`. Documented in the `col_is_paid` doc block.
+
+## `raw_marketing.spend`
+
+One row per channel × day. Spend, impressions, clicks. No user-level data — joined to `fct_marketing_spend` for attribution rollups via `dim_channels`.
+
+Key fields: `spend_id` (PK), `spend_date` (DATE), `channel`, `campaign`, `spend_amount`, `currency`, `impressions`, `clicks`.
+
+## `raw_support.tickets`
+
+One row per support ticket.
+
+Key fields: `ticket_id` (PK), `account_id`, `user_id`, `created_at`, `resolved_at` (NULL until resolved), `category`, `priority`, `csat` (1-5, NULL if no survey response).
+
+## Conventions Across All Sources
+
+### `_loaded_at` is mandatory
+
+Every source row carries `_loaded_at`. It's the freshness anchor (declared in `_sources.yml` per table) and the incremental anchor for any model materialising downstream of that source.
+
+### Naming
+
+- Snake_case throughout. No abbreviations (`subscription_id`, not `sub_id`).
+- Same concept = same column name in every model that surfaces it. `user_id` is always `user_id`, never `uid` or `userId`.
+
+### Type Canonicalisation
+
+Staging casts to one of: `TIMESTAMP`, `DATE`, `STRING`, `INT64`, `NUMERIC`, `BOOL`. No `FLOAT64` for monetary values — all currency uses `NUMERIC`. No `JSON` outside the two declared exceptions (`properties`, `line_items`).
+
+### Late Arrivals
+
+Anchored on `_loaded_at`, not source-event time. The 36-hour lookback on `int_events_normalized` is the authoritative dedup window for the funnel; events older than 36h that arrive late will not be picked up by the incremental run and require a `--full-refresh`.
+
+### Identity
+
+A user has at most one `user_id`. They may have many `anon_id`s (one per browser/device). `int_identity_stitched` resolves anon→user with a 90-day lookback (`identity_stitching_lookback_days`). Beyond that window, stitches do not propagate — see `decisions.md` for rationale.
+
+## Generating Synthetic Data
+
+The reference dataset is produced by `scripts/generate_synthetic_data.py`. It generates 50K users × 24 months and uploads to the raw datasets. Run targets:
+
+```
+uv run python scripts/generate_synthetic_data.py --users 50000 --months 24 --upload
+```
+
+Determinism is required: a fixed `--seed` produces byte-identical output. CI uses a deterministic small dataset for build verification.
+
+## See Also
+
+- [`docs/architecture.md`](architecture.md) — where these events flow once they hit staging.
+- [`docs/metric-contract.md`](metric-contract.md) — what we measure from these events.
+- [`models/staging/<domain>/_models.yml`](../models/staging) — the executable contract (enforced at parse time).

--- a/docs/metric-contract.md
+++ b/docs/metric-contract.md
@@ -1,0 +1,272 @@
+# Metric Contract
+
+Canonical metric definitions. Every headline KPI in this project resolves to exactly one model and one column. If a number on a dashboard, in an answer, or in an ad-hoc query doesn't match one of these definitions, the dashboard is wrong.
+
+## Conventions
+
+- **Grain** — what one row represents at the source-of-truth model.
+- **Formula** — the computation. Where it's an aggregation, the aggregation is named.
+- **Source model** — the model where the metric is canonically computed. Downstream consumers reference this.
+- **Owner** — the team / role accountable for the definition. Changes require their sign-off and a `decisions.md` entry.
+- **Test evidence** — the test file proving the metric holds invariants.
+
+Currency: all monetary values are `NUMERIC`, normalised to USD-equivalent in the synthetic dataset (single-currency assumption). Multi-currency support deferred.
+
+---
+
+## Activation & Acquisition
+
+### Signups
+
+| Field | Value |
+|---|---|
+| Definition | Distinct users with a `signup` event in the funnel. |
+| Grain | One row per signup event (a user signs up exactly once). |
+| Formula | `count(*) from fct_signups` over a time window. |
+| Source model | `models/marts/core/fct_signups.sql` |
+| Time anchor | `signup_date_key` |
+| Owner | Growth analytics |
+| Test evidence | `_models.yml` `unique` + `not_null` on `user_key`. |
+
+### Activations
+
+| Field | Value |
+|---|---|
+| Definition | Users who completed an activation action within the activation window. |
+| Activation actions | `complete_onboarding`, `create_first_report`, `invite_teammate`, `connect_datasource` (see `event-contract.md`). |
+| Grain | One row per user per activation date. |
+| Formula | `count(*) from fct_activations` over a time window. |
+| Source model | `models/marts/core/fct_activations.sql` |
+| Owner | Growth analytics |
+| Test evidence | `_models.yml` `unique` on `farm_fingerprint(concat(user_id, '|', date))`. |
+
+### Time to Activate
+
+| Field | Value |
+|---|---|
+| Definition | Hours from `signup` event to first `activation` event for the same user. |
+| Grain | One row per activated user. |
+| Formula | Carried on the `activation` event as `time_to_activate_hours` (set by the producing system). |
+| Source model | `fct_activations.time_to_activate_hours` |
+| Owner | Growth analytics |
+
+### Activation Rate
+
+| Field | Value |
+|---|---|
+| Definition | Activated users ÷ signed-up users, for a cohort. |
+| Grain | Aggregation over a signup cohort (defined by signup week or month). |
+| Formula | `count(distinct activated_user_id) / count(distinct signup_user_id)` within cohort. |
+| Source model | Computed at consumption time from `fct_signups` and `fct_activations`. Pre-aggregated form available in `fct_retention_cohorts` for cohort-week × period. |
+| Owner | Growth analytics |
+
+---
+
+## Revenue (MRR)
+
+The MRR motion model is the single source of truth for all revenue movement. Anywhere MRR appears, it resolves to a sum over `fct_mrr_movements.mrr_delta`.
+
+### MRR Movements
+
+| Field | Value |
+|---|---|
+| Definition | Every change in monthly recurring revenue, classified into one of five types. |
+| Grain | One row per subscription state change per account. |
+| Movement types | `new`, `expansion`, `contraction`, `churn`, `reactivation`. |
+| Source model | `models/marts/billing/fct_mrr_movements.sql` |
+| Classification logic | `models/intermediate/billing/int_mrr_movements.sql` — based on prior MRR, new MRR, and subscription `event_type`. |
+| Owner | Revenue / finance analytics |
+| Test evidence | `tests/invariants/invariants_fixture_session_boundary_split.sql` (movement arithmetic), `tests/reconciliation/reconciliation_fct_mrr_movements_vs_int.sql`, `tests/fanout/fanout_fct_mrr_movements_vs_int_mrr_movements.sql`. |
+
+Classification rules (canonical, lifted from `int_mrr_movements`):
+
+| Subscription `event_type` | MRR delta | `movement_type` |
+|---|---|---|
+| `subscription_start` (first ever) | > 0 | `new` |
+| `reactivation` | > 0 | `reactivation` |
+| `cancellation` | full prior MRR → 0 | `churn` |
+| `upgrade` / plan change | > 0 | `expansion` |
+| `downgrade` / plan change | < 0 | `contraction` |
+
+### Net MRR
+
+| Field | Value |
+|---|---|
+| Definition | Cumulative sum of `mrr_delta` over time. |
+| Formula | `sum(mrr_delta)` from `fct_mrr_movements`. |
+| Owner | Revenue analytics |
+
+### Net Revenue Retention (NRR)
+
+| Field | Value |
+|---|---|
+| Definition | (Starting MRR + expansion − contraction − churn) ÷ Starting MRR, per cohort. |
+| Grain | One row per account cohort × period. |
+| Formula | Computed from `fct_mrr_movements` filtered to a starting-MRR cohort. |
+| Source model | Computed at consumption time. Pre-aggregated form planned in `rpt_nrr_by_cohort` (not yet built). |
+| Owner | Revenue analytics |
+
+### Invoices
+
+| Field | Value |
+|---|---|
+| Definition | One row per invoice issued. |
+| `is_paid` rule | `true` iff `paid_at IS NOT NULL AND refunded_at IS NULL`. Refunded invoices flip back to `false`. |
+| Source model | `models/marts/billing/fct_invoices.sql` |
+| Test evidence | `tests/invariants/invariants_fct_invoices_is_paid_consistency.sql`. |
+
+---
+
+## Engagement
+
+### Sessions
+
+| Field | Value |
+|---|---|
+| Definition | A user's contiguous activity in the product, split by 30 minutes of inactivity. |
+| Sessionisation rule | A new session starts after `session_timeout_seconds` (1800) of inactivity. |
+| Grain | One row per session. |
+| Source model | `models/marts/product/fct_sessions.sql` (from `int_sessions`). |
+| Owner | Product analytics |
+| Test evidence | `tests/invariants/invariants_int_sessions_no_overlap.sql`, `tests/fanout/fanout_fct_sessions_vs_int_sessions.sql`. |
+
+Anonymous sessions (`user_id IS NULL`) are allowed in the fact — the `not_null` test on `user_id` is intentionally relaxed.
+
+### Engagement State
+
+| Field | Value |
+|---|---|
+| Definition | A user's engagement classification snapshot, computed weekly. |
+| States | `new`, `active`, `at_risk`, `dormant`, `churned`. |
+| Boundaries | `active` if last activity ≤ `engagement_active_threshold_days` (14d) from snapshot end; `dormant` if > `engagement_dormant_threshold_days` (42d). |
+| Time anchor | `snapshot_week_end` (week_start + 6) — not `snapshot_week_start`. |
+| Source model | `models/intermediate/engagement/int_engagement_states.sql` |
+| Surfaced in | `dim_users.engagement_state` (current state), `int_engagement_states` (historical). |
+| Owner | Product analytics |
+
+### Re-engagement
+
+| Field | Value |
+|---|---|
+| Definition | A previously dormant or churned user who returns to active state. |
+| Flag | `dim_users.is_re_engaged` (BOOLEAN). |
+| Owner | Product analytics |
+
+### Feature Usage
+
+| Field | Value |
+|---|---|
+| Definition | Count of `feature_use` events per user per feature. |
+| Grain | One row per `(user_id, feature_name, event_date)`. |
+| Source model | `models/marts/product/fct_feature_usage.sql` |
+| Filter | Anonymous events excluded (`user_id IS NOT NULL`). |
+| Owner | Product analytics |
+
+---
+
+## Retention
+
+### Retention Cohorts
+
+| Field | Value |
+|---|---|
+| Definition | Of users activated in cohort week W, the share returning to perform a session-generating action by period P (W1, W2, W3, W4, M2, M3, M6, M12). |
+| Grain | One row per `(cohort_week_start_date, retention_period)`. |
+| Source model | `models/marts/core/fct_retention_cohorts.sql` |
+| Maturity guard | A cohort × period is only reported if the period is at least `retention_maturity_guard_days` (7) past the snapshot date. Otherwise `is_period_complete = false` and the rate is NULL. |
+| Owner | Growth analytics |
+| Test evidence | `tests/invariants/invariants_fct_retention_cohorts_rate_bounds.sql`, `tests/fanout/fanout_fct_retention_cohorts_period_count.sql`. |
+
+The maturity guard exists because incomplete trailing periods otherwise render as artificial 0% retention — a chart cliff that does not reflect reality.
+
+---
+
+## Marketing
+
+### Marketing Spend
+
+| Field | Value |
+|---|---|
+| Definition | Spend, impressions, clicks, CPC, and CTR per channel × day. |
+| Grain | One row per `(channel, spend_date)`. |
+| Source model | `models/marts/marketing/fct_marketing_spend.sql` |
+| Derived fields | `cost_per_click = spend_amount / nullif(clicks, 0)`, `click_through_rate = clicks / nullif(impressions, 0)`. |
+| Owner | Marketing analytics |
+
+### Attribution
+
+| Field | Value |
+|---|---|
+| First-touch channel | First UTM-tagged channel observed for an anon_id/user_id, within the attribution window. |
+| Last-touch channel | Most recent UTM-tagged channel before activation. |
+| Window | `attribution_lookback_days` (30d) pre-activation. |
+| Source model | `models/intermediate/cross_domain/int_attribution.sql`. Surfaced as FKs on `dim_users`. |
+| Owner | Growth + marketing analytics |
+
+---
+
+## Support
+
+### Tickets
+
+| Field | Value |
+|---|---|
+| Definition | One row per support ticket. |
+| Source model | `models/marts/support/fct_support_tickets.sql` |
+| Resolution | A ticket is resolved iff `resolved_at IS NOT NULL`. |
+| Test evidence | `tests/invariants/invariants_fct_support_tickets_resolved_has_time.sql`. |
+| Owner | Support analytics |
+
+### CSAT
+
+| Field | Value |
+|---|---|
+| Definition | Customer satisfaction score, 1-5, captured per ticket via post-resolution survey. |
+| Source field | `fct_support_tickets.csat` (NULL if no survey response). |
+| Aggregation | Mean over responded tickets. Non-response handling: excluded from numerator and denominator. |
+| Owner | Support analytics |
+
+### Account Health Score
+
+| Field | Value |
+|---|---|
+| Definition | Composite 0-100 score blending product usage, billing posture, and support signals over a trailing window. |
+| Window | `account_health_trailing_days` (28d). |
+| Source model | `models/intermediate/cross_domain/int_account_health.sql`. Surfaced as `dim_accounts.health_score`. |
+| CSAT handling | Accounts with no support data contribute the neutral score (70), not a perfect 5. |
+| Owner | Customer success analytics |
+
+---
+
+## Experiments
+
+### Experiment Exposures
+
+| Field | Value |
+|---|---|
+| Definition | A user was exposed to variant V of experiment E at time T. |
+| Grain | Factless — one row per `(user_id, experiment_id, variant_id, exposure_time)`. |
+| Source model | `models/marts/product/fct_experiment_exposures.sql` |
+| Many-to-many bridge | `bridge_user_experiments` |
+| Owner | Product analytics |
+
+### Experiment Results
+
+| Field | Value |
+|---|---|
+| Definition | Per-variant conversion rate against a declared activation event, scoped to users exposed before activation. |
+| Source model | `models/intermediate/engagement/int_experiment_results.sql` |
+| Owner | Product analytics |
+
+---
+
+## Changing a Metric
+
+A metric in this contract is treated as a public API. Changing one requires:
+
+1. A `decisions.md` entry describing what changed and why.
+2. Updating this file with the new definition and a dated note.
+3. The owner's sign-off.
+4. A migration plan if downstream consumers (Lightdash, agents) need to be updated in lockstep.
+
+Adding a metric requires the same: source model, grain, owner, test evidence. No metric ships without all four.

--- a/docs/metric-contract.md
+++ b/docs/metric-contract.md
@@ -103,7 +103,7 @@ Classification rules (canonical, lifted from `int_mrr_movements`):
 | Definition | (Starting MRR + expansion − contraction − churn) ÷ Starting MRR, per cohort. |
 | Grain | One row per account cohort × period. |
 | Formula | Computed from `fct_mrr_movements` filtered to a starting-MRR cohort. |
-| Source model | Computed at consumption time. Pre-aggregated form planned in `rpt_nrr_by_cohort` (not yet built). |
+| Source model | Computed at consumption time from `fct_mrr_movements`. No pre-aggregated mart model. |
 | Owner | Revenue analytics |
 
 ### Invoices


### PR DESCRIPTION
## Summary

Backfills four user-facing reference docs called out by the foundation epic (#281) and the required-docs orchestration ticket (#297 in agentic-hub).

- **`docs/architecture.md`** — three-layer system design, materialisation policy, DAG boundaries enforced by `dbt-project-evaluator`, naming conventions, cross-repo position. Replaces "read the README and infer the rest" with a dedicated reference.
- **`docs/event-contract.md`** — exact schemas for `raw_funnel.events`, `raw_billing.subscriptions`, `raw_billing.invoices`, `raw_marketing.spend`, `raw_support.tickets`. Documents the `event_type` enums, `_loaded_at` vs `event_time` semantics, late-arrival handling, and identity rules.
- **`docs/metric-contract.md`** — canonical definitions for every headline KPI: signups, activations, MRR movements (with the five-type classification table), NRR, retention cohorts (incl. the maturity guard), engagement state thresholds, CSAT, account health. Each metric carries source model, grain, owner, and test-file evidence.
- **`RUNBOOK.md`** — setup, daily commands, CI behaviour, pre-commit hook flow, common-failure recipes.

## Why

These four docs are listed as required in the issue acceptance criteria but never landed. The repo currently has 38 models, real tests, and active correctness reviews — but a hiring manager or new contributor opening the repo can't easily find: what does the system do? what's a signup? how do I run it?

This PR closes that gap without adding any model code.

## Validation

- Every cross-reference (paths, models, vars, test files) was checked against the working tree before commit.
- All vars referenced match `dbt_project.yml`.
- All test files referenced exist under `tests/`.
- No model code changed; lint and dbt parse will run on the new branch as usual.

## Out of Scope (deferred)

Two docs from #297 are deliberately deferred because they're internal-process rather than user-facing:

- `docs/dbt-guidelines.md` (dbt-specific style — currently covered piecemeal by `CLAUDE.md` and `docs/doc-block-convention.md`)
- `docs/data-boundary.md` (data ownership / freshness SLAs / PII)

These should be a follow-up PR once these four have settled.

## Related

- Closes part of agentic-hub#297 (4 of 6 docs from the required-docs ticket)
- Advances agentic-hub#281 (foundation epic) toward closure