### PR TITLE
docs: add dbt-guidelines and data-boundary (closes #297)

### DIFF
--- a/docs/data-boundary.md
+++ b/docs/data-boundary.md
@@ -1,0 +1,113 @@
+# Data Boundary
+
+What this project owns, what it consumes, and what it does not touch. The boundary is intentionally narrow: the project's job is to model five raw source domains into a Kimball star schema. Anything outside that is somebody else's system.
+
+## Ownership
+
+### Owned by this project
+
+- The five staging models (`stg_*`) that define the contract between the raw datasets and the rest of the warehouse.
+- All intermediate models — every business rule that turns raw events into measurable behaviour.
+- All mart models — facts, dimensions, bridges, and any aggregations or reports built on top.
+- All test logic in `tests/` and per-model tests in `_models.yml`.
+- The doc-tag library in `models/<layer>/<layer>.md`.
+- Project variables in `dbt_project.yml`.
+- The synthetic data generator (`scripts/generate_synthetic_data.py`) — the canonical reproducer for the raw datasets.
+
+If a column changes shape inside any of the above, that's a change to this project.
+
+### Not owned by this project
+
+- The raw datasets themselves (`raw_funnel`, `raw_billing`, `raw_marketing`, `raw_support`). In a real organisation these would be produced by upstream ingestion (Fivetran, Segment, application events). For this portfolio project, the synthetic generator stands in for those producers — but the *contract* (column names, types, semantics) is what this project depends on, not the implementation.
+- BI dashboards, agents, and downstream applications consuming the marts. Declared as `exposures` (see below) but not implemented in this repo.
+- The Lightdash semantic layer (planned in `b2b-saas-lightdash`).
+- The agent / Q&A surface (planned in `analytics-agent`).
+
+## Sources and SLAs
+
+All sources land via the same five raw tables. Freshness SLAs are uniform — declared in `_sources.yml` per table.
+
+| Source | Table | Freshness warn | Freshness error | Producer (notional) |
+|---|---|---|---|---|
+| `funnel` | `events` | 24h since `_loaded_at` | 48h | Product event collector |
+| `billing` | `subscriptions` | 24h | 48h | Subscription management system |
+| `billing` | `invoices` | 24h | 48h | Billing system |
+| `marketing` | `spend` | 24h | 48h | Marketing platform exports |
+| `support` | `tickets` | 24h | 48h | Support ticketing system |
+
+Every source row carries `_loaded_at` — the row's BigQuery arrival time. It is the freshness anchor and the incremental anchor for any model downstream.
+
+When a source breaches the warn threshold, the source-freshness test surfaces in CI as a warning. The error threshold blocks merge.
+
+## Meta Tags on Marts
+
+Every mart model declares four meta keys. They make ownership, sensitivity, cadence, and importance machine-readable.
+
+| Key | Domain | Value seen in repo |
+|---|---|---|
+| `owner` | Team / role accountable for the model | `analytics` |
+| `pii` | `true` if any column contains PII | `false` everywhere |
+| `sla` | Build cadence: `hourly`, `daily`, `weekly` | `daily` |
+| `tier` | Importance: 1 (critical) – 5 (experimental) | `1`, `2`, or `3` |
+
+The tier values in use:
+- **Tier 1** — conformed dimensions (`dim_users`, `dim_accounts`, `dim_date`, `dim_channels`) and the headline facts they support (`fct_signups`, `fct_activations`, `fct_mrr_movements`, `fct_subscriptions`, `fct_invoices`, `fct_retention_cohorts`).
+- **Tier 2** — domain-specific operational facts (`fct_sessions`, `fct_feature_usage`, `fct_support_tickets`, `fct_marketing_spend`).
+- **Tier 3** — experimentation surface (`fct_experiment_exposures`, `dim_experiments`, `bridge_user_experiments`, `dim_sessions`).
+
+In a real organisation the tier would drive on-call response and incident escalation. In this project it documents priority for build-time budgeting and selective `--select` strategies.
+
+## PII
+
+The synthetic dataset contains no real personal data. The generator produces fabricated identifiers, fabricated event payloads, and fabricated marketing UTMs. Every mart model carries `pii: false`.
+
+If this project were adapted to ingest a real production source, the boundary would shift as follows:
+
+- Columns to classify as PII: `user_id` (if it maps to a real person), `email` (if present in source), `ip_address`, `user_agent` when combined with stable identifiers, and any free-text `properties` payload from product events.
+- Staging would be the layer responsible for hashing, tokenisation, or column-dropping. Marts should never see raw PII.
+- The `pii: true` flag on a mart model would trigger downstream access controls (row-level security, masking policies) that this repo does not currently implement.
+
+`docs/event-contract.md` documents the exact source columns; classifying which would be PII in a real ingest is straightforward from that surface.
+
+## Retention
+
+The project does not implement retention or deletion of source data — that is the upstream producer's responsibility. The marts are derived state and can be rebuilt from sources at any time.
+
+For the synthetic dataset:
+- Generator produces 24 months of history with a fixed `--seed`, so any "retention" question is answered by re-running the generator at a different `--months` value.
+- The CI per-PR BQ dataset is deleted by `pr-teardown.yml` on PR close.
+- Dev and prod datasets are user-managed (no in-project lifecycle policy).
+
+For a real adaptation: GDPR-style erasure would land at the staging layer (delete the rows in `raw_*`, rebuild downstream with `dbt build --full-refresh`). Marts contain no source-of-record state that exists nowhere else, so erasure is always a re-derivation, never a manual mart edit.
+
+## Downstream Consumers (Exposures)
+
+Three exposures are declared in `models/marts/exposures.yml`. They serve as documented downstream dependencies — every model they `depends_on` is protected from breaking changes without the consumer being part of the conversation.
+
+| Exposure | Type | Depends on |
+|---|---|---|
+| `product_analytics_dashboard` | dashboard | `fct_sessions`, `fct_feature_usage`, `fct_signups`, `fct_activations`, `dim_users`, `dim_accounts`, `dim_sessions` |
+| `revenue_dashboard` | dashboard | `fct_mrr_movements`, `fct_subscriptions`, `fct_invoices`, `dim_accounts` |
+| `growth_and_retention_dashboard` | dashboard | `fct_retention_cohorts`, `fct_marketing_spend`, `fct_experiment_exposures`, `dim_channels`, `dim_experiments` |
+
+All three are notional — they document the intended consumer surface for the planned Lightdash project, not actual hosted dashboards.
+
+## What Crossing the Boundary Looks Like
+
+A change is "outside this project" if it would require:
+- Editing a raw dataset (run the generator instead).
+- Adding a consumer (declare an exposure, build the consumer in the sibling repo).
+- Changing the contract on a source (coordinate with the notional upstream producer — for this project, the generator script).
+
+A change is "inside this project" if it would require:
+- Adding or modifying a staging, intermediate, or mart model.
+- Adding or modifying a test.
+- Changing a project variable.
+- Adding a doc tag or updating an existing one.
+
+## See Also
+
+- [`docs/architecture.md`](architecture.md) — three-layer system design.
+- [`docs/event-contract.md`](event-contract.md) — exact source schemas.
+- [`docs/metric-contract.md`](metric-contract.md) — what each canonical metric is.
+- [`models/marts/exposures.yml`](../models/marts/exposures.yml) — the executable exposure declarations.

--- a/docs/dbt-guidelines.md
+++ b/docs/dbt-guidelines.md
@@ -1,0 +1,216 @@
+# dbt Guidelines
+
+dbt-specific conventions for this repo. Every rule here is either enforced by a hook, a CI check, or a `dbt-project-evaluator` rule. The goal is that an agent or a new contributor can write a correct model without reading every existing one.
+
+## Naming
+
+### Models
+
+| Layer | Pattern | Example |
+|---|---|---|
+| Staging | `stg_<source>__<entity>` (double underscore) | `stg_funnel__events`, `stg_billing__invoices` |
+| Intermediate | `int_<concept>` | `int_mrr_movements`, `int_identity_stitched` |
+| Intermediate — source-specific prep | `int_<source>_prep` | `int_invoices_prep`, `int_marketing_spend_prep` |
+| Intermediate — union of multiple sources | `int_<entity>_unioned` | (none current) |
+| Mart fact | `fct_<entity>` | `fct_signups`, `fct_mrr_movements` |
+| Mart dimension | `dim_<entity>` | `dim_users`, `dim_accounts` |
+| Mart bridge | `bridge_<m2m>` | `bridge_user_experiments` |
+| Mart aggregation | `agg_<entity>_<grain>` | `agg_sessions_weekly` (not yet built) |
+| Mart report | `rpt_<topic>` | `rpt_funnel_summary` (not yet built) |
+| Mart blend | `mart_<entity>` | `mart_account_summary` (not yet built) |
+
+Subdirectories provide domain context. The model name itself never repeats the directory: `marts/billing/fct_invoices.sql`, not `marts/billing/fct_billing_invoices.sql`.
+
+### Columns
+
+- snake_case throughout.
+- No abbreviations. `subscription_id`, never `sub_id`. `user_id`, never `uid` or `userId`.
+- Same business concept = same column name in every model that surfaces it.
+- Surrogate keys end in `_key`, always `INT64`, always built with `farm_fingerprint()`.
+- Foreign keys are surrogate keys named for the dimension they point to (`account_key`, `user_key`, `date_key`).
+- Role-playing FKs are suffixed (`signup_date_key`, `activation_date_key`, `first_touch_channel_key`).
+- Boolean columns start with `is_`, `has_`, or `was_`.
+
+## `ref()` vs `source()`
+
+Enforced by `dbt-project-evaluator` DAG rules at `severity: error`:
+
+| Layer | May `ref()` | May `source()` |
+|---|---|---|
+| Staging | seeds only | yes — the only layer that may |
+| Intermediate | staging, other intermediate, seeds | no |
+| Marts (`fct_`, `dim_`, `bridge_`) | intermediate, seeds, conformed dimensions | no |
+| Marts (`agg_`, `rpt_`, `mart_`) | intermediate, marts, seeds | no |
+
+Violations are caught by `fct_marts_or_intermediate_dependent_on_source` and friends in CI.
+
+## Materialisation
+
+Defaults configured in `dbt_project.yml`:
+
+| Layer | Default | Why |
+|---|---|---|
+| staging | `view` | Source shapes only — storage cost > query cost. |
+| intermediate | `view` | Logic is composable; tables would freeze stale state. |
+| marts | `table` | Stable query performance for downstream consumers. |
+
+**The one incremental model:** `int_events_normalized`. Strategy: `merge` on `event_id`; lookback window from `events_incremental_lookback_hours` (36h) anchored on `max(_loaded_at)` of the last run — **not** `current_timestamp` and **not** `event_time`.
+
+When to deviate from defaults:
+
+- **Intermediate → table** — only when a downstream model rebuilds frequently and the view is expensive (BQ slot pressure, repeated joins). Note the reason in `decisions.md`.
+- **Marts → incremental** — only when the table grows large enough that full rebuilds violate the build-time budget. Choose `merge` on the natural PK; never `insert_overwrite` without a partition column.
+- **Staging → anything other than view** — don't. Staging is a contract; a non-view staging model means the contract is doing transformation work it shouldn't.
+
+## Contracts
+
+`contract.enforced: true` is mandatory on:
+- All staging models — the project's interface to its sources.
+- All mart `fct_`, `dim_`, `bridge_` models — the project's interface to its consumers.
+
+Contracts are **optional** on mart `agg_`, `rpt_`, `mart_` models. Use them where the model is consumed by an external system that benefits from a stable schema.
+
+Contracts are **forbidden** on intermediate models — intermediate is internal scaffolding and locking the schema would block routine refactors.
+
+## Documentation
+
+### The single rule
+
+**Every column and model description uses `doc(...)` blocks.** Inline `description: "..."` strings are banned. Enforced by `scripts/lint-doc-blocks.sh` at pre-commit and in CI.
+
+Full convention: [`docs/doc-block-convention.md`](doc-block-convention.md).
+
+### Where the doc blocks live
+
+| Layer | File |
+|---|---|
+| Staging | `models/staging/staging.md` |
+| Intermediate | `models/intermediate/intermediate.md` |
+| Marts | `models/marts/marts.md` |
+
+dbt resolves doc tags globally, so a doc tag created in `staging.md` can be referenced from any layer downstream.
+
+### Naming pattern
+
+| Scope | Pattern |
+|---|---|
+| Shared column | `col_<column>` |
+| Domain-qualified column | `col_<domain>_<column>` |
+| Model | `<model_name>` |
+| Source | `src_<source>` |
+| Source table | `src_<source>_<table>` |
+| Seed | `seed_<seed_name>` |
+
+### When to reuse vs create
+
+- Column flows unchanged through layers → reuse the existing `col_` block via `doc('col_x')`.
+- Column is transformed or gains new meaning → create a new block.
+- Same column name, different semantics across domains → domain-qualify (`col_billing_status` vs `col_ticket_status`).
+
+## Meta Tags (Marts)
+
+Every mart model declares `meta:` with four keys. Required, validated by review.
+
+```yaml
+- name: fct_signups
+  description: '{{ doc("fct_signups") }}'
+  config:
+    contract:
+      enforced: true
+  meta:
+    owner: analytics      # team / role accountable
+    pii: false            # true if any column contains PII
+    sla: daily            # build cadence: hourly | daily | weekly
+    tier: 1               # 1=critical, 2=important, 3=convenience, 4=internal, 5=experimental
+```
+
+Values currently in use across the marts:
+- `owner: analytics` (single owner — see [`docs/data-boundary.md`](data-boundary.md))
+- `pii: false` everywhere (the synthetic dataset contains no real PII)
+- `sla: daily` everywhere
+- `tier: 1` (conformed dims + core facts), `tier: 2`, `tier: 3` (less critical)
+
+## Tests
+
+The full strategy lives in [`docs/quality-gates.md`](quality-gates.md). The short version:
+
+| Test category | Where | Severity policy |
+|---|---|---|
+| PK (`unique` + `not_null`) | `_models.yml` | always `error` |
+| `accepted_values` | `_models.yml` | `error` |
+| `relationships` (FK) | `_models.yml` | `warn` (cost-aware) |
+| Invariants | `tests/invariants/` | `error` |
+| Reconciliation | `tests/reconciliation/` | `error` with declared tolerance |
+| Fanout | `tests/fanout/` | `error` if ratio > 1.01 |
+| Contracts smoke | `tests/contracts/` | `error`, CI-only |
+| Source freshness | `_sources.yml` | warn 24h, error 48h |
+
+Test file naming: `tests/<category>/<category>_<scope>_<intent>.sql`. Example: `invariants_fct_invoices_is_paid_consistency.sql`.
+
+### TDD gate
+
+`scripts/tdd-gate.sh` runs on `pre-push`. A model change without a corresponding test change blocks the push. To bypass for genuinely test-only or doc-only changes, the script auto-detects the diff shape — no flag needed.
+
+## SQL Style
+
+Enforced by sqlfluff (`.sqlfluff`). The hand-rules below are the ones the linter doesn't catch.
+
+- Lowercase keywords (`select`, `from`, `where`).
+- 4-space indent, trailing commas.
+- No `select *` — explicit column lists in every model. The lint rule catches this; the convention catches it earlier.
+- CTEs over subqueries. Name CTEs for what they hold, not what they do (`active_users`, not `filter_active`).
+- One CTE per concept. A 12-CTE model is fine if each CTE is named and ~5–15 lines; a 3-CTE model with one 80-line CTE is not.
+- Prefer `group by all` over column ordinals.
+- Multi-source unions use `union all` with **explicit matching column lists** — never `select *` even if the upstream models agree today.
+- Surrogate keys: `farm_fingerprint(concat(a, '|', b))` with a literal pipe separator. Never bare concatenation (collision risk).
+
+## Custom Macros
+
+Two custom macros, both in `macros/`:
+
+- `dedup_events_row_number.sql` — canonical row-number dedup used by `int_events_normalized`. Defined once; never re-implement.
+- `generate_schema_name.sql` — schema-name override so per-PR CI runs land in their own dataset.
+
+**No other custom macros.** If a transformation feels macro-worthy, first check whether `dbt_utils` or `dbt_expectations` already provides it; both packages are installed.
+
+## Project Variables
+
+All business-policy constants are project variables, defined once in `dbt_project.yml`. Changing one requires a `decisions.md` entry.
+
+| Variable | Default | Owner |
+|---|---|---|
+| `session_timeout_seconds` | 1800 | Sessionisation policy |
+| `attribution_lookback_days` | 30 | Marketing attribution window |
+| `account_health_trailing_days` | 28 | Account health snapshot window |
+| `engagement_active_threshold_days` | 14 | Engagement state classifier |
+| `engagement_dormant_threshold_days` | 42 | Engagement state classifier |
+| `events_incremental_lookback_hours` | 36 | Incremental dedup window |
+| `identity_stitching_lookback_days` | 90 | Bounded anon→user stitch |
+| `checkout_conversion_window_days` | 30 | Checkout→sub conversion |
+| `retention_maturity_guard_days` | 7 | Cohort completeness gate |
+| `project_start_date` | `2024-01-01` | Sentinel for activity-less users |
+
+Never hardcode these values in model SQL.
+
+## Pre-Commit Hooks (Summary)
+
+Run on every commit. Full config in `.pre-commit-config.yaml`. Order matters:
+
+1. File hygiene (whitespace, EOF, YAML syntax, merge markers)
+2. `sqlfluff` lint (Jinja templater for speed; CI uses dbt templater for full accuracy)
+3. `dbt-parse`, `check-model-has-tests`, `check-model-has-properties`, `check-model-has-description`
+4. Doc-block lint
+5. Secret scan
+6. Conventional-commit message (commit-msg hook)
+7. TDD gate (pre-push hook)
+
+Never bypass with `--no-verify`. If a hook is wrong, fix the hook.
+
+## See Also
+
+- [`docs/architecture.md`](architecture.md) — system design.
+- [`docs/layers/layer-contract.md`](layers/layer-contract.md) — the executable layer rules.
+- [`docs/doc-block-convention.md`](doc-block-convention.md) — full doc-block convention.
+- [`docs/quality-gates.md`](quality-gates.md) — test severity matrix.
+- [`docs/review/pr-checklist.md`](review/pr-checklist.md) — what a PR review looks at.
+- [`docs/review/common-mistakes.md`](review/common-mistakes.md) — patterns to avoid.


### PR DESCRIPTION
## Summary

Lands the remaining two required docs from agentic-hub#297, completing the foundation-docs work that started in #90.

- **\`docs/dbt-guidelines.md\`** — dbt-specific conventions: naming (model and column), \`ref()\`/\`source()\` rules per layer, materialisation policy, contracts policy, doc-block pattern, meta tags, test categories and severities, SQL style, custom macros, project variables, pre-commit hooks.
- **\`docs/data-boundary.md\`** — what this project owns vs consumes: source ownership, freshness SLAs, meta tag interpretation, PII posture, retention, downstream exposures, and concrete rules for what counts as "outside" the project.

## Validation

- No \`{% docs %}\` Jinja in prose (the bug that broke #90's first CI run).
- All cross-references checked against the working tree.
- Project variables in \`dbt-guidelines.md\` match \`dbt_project.yml\` exactly.
- Meta tag values in \`data-boundary.md\` match what's declared across the marts \`_models.yml\` files.
- Exposures table in \`data-boundary.md\` copied from \`models/marts/exposures.yml\` verbatim.

## Closes

- Closes agentic-hub#297 (6/6 required docs landed: this PR + #90 + pre-existing \`quality-gates.md\`, \`dimensional-modeling-guidelines.md\`, \`doc-block-convention.md\`)
- Unblocks agentic-hub#281 for closure