### PR TITLE
fix: add --empty-catalog so docs deploy works without BQ auth

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -67,8 +67,12 @@ jobs:
           mkdir -p ~/.dbt
           cp profiles.yml.example ~/.dbt/profiles.yml
 
-      - name: Generate dbt docs (no compile — uses manifest, no catalog)
-        run: dbt docs generate --no-compile --target dev
+      - name: Generate dbt docs (no compile, empty catalog — no BQ connection)
+        # --no-compile   : skip query compilation (manifest already covers structure)
+        # --empty-catalog: skip the catalog query that requires a live BQ connection
+        # Net result: rendered site has model graph, descriptions, tests, and lineage,
+        # but no BQ-derived column types or row counts. Acceptable for a portfolio piece.
+        run: dbt docs generate --no-compile --empty-catalog --target dev
 
       - name: Stage docs site
         run: |


### PR DESCRIPTION
## Summary

The docs workflow (added in #92) failed on its first run with:

\`\`\`
AttributeError: 'NoneType' object has no attribute 'close'
  at dbt/task/docs/generate.py:255 (adapter.connection_named(\"generate_catalog\"))
\`\`\`

Root cause: \`dbt docs generate --no-compile\` still opens a BigQuery connection to populate \`catalog.json\`. The docs job has no GCP auth (deliberate — we don't want to burn BQ slots on every docs render).

## Fix

Add \`--empty-catalog\`. Skips the catalog query entirely. Site still has the model graph, descriptions, tests, and lineage — only BQ-derived column types and row counts are missing. The header comment in the workflow already documented this trade-off.

## Validation

Will trigger automatically on the next push to main after merge (via the existing \`workflow_run\` trigger). I'll watch the run.