### PR TITLE
feat: severity graduation policy for FK tests (closes #305)

### DIFF
--- a/decisions.md
+++ b/decisions.md
@@ -211,3 +211,11 @@
 - Added determinism comments on identity stitching and account acquisition join
 - Corrected decisions.md PR #55 entry (was about `arguments:` deprecation, not `tests:` → `data_tests:`)
 - Cleaned 14 stale git worktrees
+
+## 2026-05-11: Severity graduation policy for FK relationships tests
+**Why:** All 37 `relationships:` tests across the marts inherited dbt's default severity (`error`), meaning a single orphan row would block merge. This is right for PKs and enums, but too strict for FKs — small referential gaps from late-arriving anonymous events are tolerable while large gaps signal real upstream breaks.
+**What changed:**
+- Added explicit `config: { severity: warn, warn_if: ">0", error_if: ">10" }` to all 37 `relationships:` tests in the five mart `_models.yml` files
+- Expanded `docs/quality-gates.md` into a formal severity-and-thresholds policy: per-category rationale, configuration-site reference, escalation paths, and explicit documentation of CI's interpretation of severity
+- Documented the source freshness deviation from the original orchestration spec (24h/48h vs 12h/24h): synthetic data is always stale; tightening freshness adds no signal
+- No changes to PK/enum/invariant/reconciliation/fanout/contract test severities — those remain `error` (documented as such, not changed)

--- a/docs/quality-gates.md
+++ b/docs/quality-gates.md
@@ -1,24 +1,93 @@
-# Quality Gate Thresholds — b2b-saas-dbt
+# Quality Gate Thresholds
 
-| Test type | Severity | Threshold | Notes |
-|-----------|----------|-----------|-------|
-| PK (unique + not_null) | error | any failure | Non-negotiable on all models |
-| Accepted values / enum | error | any failure | |
-| FK relationships | warn | >0 rows | Warn to avoid full-scan cost on large tables |
-| Invariants | error | any failure | |
-| Reconciliation | error | tolerance per test | Default: abs diff > 0.01 |
-| Fanout | error | ratio > 1.01 | Mart rows / intermediate rows |
-| Contracts | error | any missing | CI-only (requires built tables) |
-| Source freshness | warn at 12h, error at 24h | per-source | Configured in _sources.yml |
+The severity policy for every test category in this project. Severity governs whether a failure blocks merge (`error`) or surfaces as a non-blocking signal (`warn`). For tolerance-based tests, `warn_if` and `error_if` express the boundary in row counts.
 
-## Notes
+## Policy
 
-**FK severity:** `warn` prevents CI blocking on expensive full-table relationship scans while still
-surfacing referential integrity issues. Escalate to `error` if the FK is the sole referential
-integrity gate for a given column.
+| Test category | Severity | Threshold | Configuration site | Rationale |
+|---|---|---|---|---|
+| PK — `unique` + `not_null` | `error` | 0 failures | per-column in `_models.yml` (default severity) | Data integrity is non-negotiable. A duplicate or null primary key is always a bug. |
+| `accepted_values` (enum) | `error` | 0 failures | per-column in `_models.yml` (default severity) | Enum drift is silent corruption — fail fast. |
+| FK — `relationships` | `warn` | `warn_if: ">0"`, `error_if: ">10"` | explicit `config:` per-test in `_models.yml` | Small referential gaps are tolerable (e.g., late-arriving anonymous events with no resolved `user_id`). Large gaps signal a real upstream break and should block. |
+| Invariant tests | `error` | 0 failures | `{{ config(severity='error') }}` in `tests/invariants/*.sql` | Each invariant encodes a business or technical guarantee — any failure means an assumption broke. |
+| Reconciliation tests | `error` | declared tolerance per test (default abs diff > 0.01) | `{{ config(severity='error') }}` in `tests/reconciliation/*.sql` | Mart totals must reconcile to intermediate totals. Drift > tolerance means assembly logic dropped, added, or mutated rows. |
+| Fanout tests | `error` | mart_rows ≠ source_rows (exact, with declared exceptions) | `{{ config(severity='error') }}` in `tests/fanout/*.sql` | Row multiplication is always wrong — either grain expansion in a join or accidental row deletion. |
+| Contract tests | `error` | 0 missing tables | `tests/contracts/contracts_mart_tables_populated.sql` | All 17 mart models must be built before CI passes. CI-only — fails on a fresh dev schema. |
+| Source freshness | `warn at 24h`, `error at 48h` | `_loaded_at` age per source | `_sources.yml` per source | Synthetic data is always "stale" in CI (`continue-on-error: true` on the freshness step). The thresholds document the pattern; in a real production setup they would be tightened to align with upstream SLAs. |
 
-**Reconciliation tolerance:** Each test declares its own tolerance in the config description.
-The default `abs diff > 0.01` matches the precision used in `reconciliation_int_mrr_movements_net_mrr.sql`.
+## How Severity Is Set
 
-**Contracts test:** CI-only — the smoke test in `tests/contracts/` requires all mart tables to be
-built before it can run. It will fail on a fresh dev schema before `dbt build`.
+### Per-column tests in `_models.yml`
+
+`unique`, `not_null`, and `accepted_values` inherit dbt's default severity (`error`) and require no explicit config. A failure on any of these blocks merge.
+
+`relationships` tests carry explicit `config:` per-instance:
+
+```yaml
+- relationships:
+    arguments:
+      to: ref('dim_users')
+      field: user_key
+    config:
+      severity: warn
+      warn_if: ">0"
+      error_if: ">10"
+```
+
+The `warn_if` / `error_if` thresholds are expressions evaluated against the count of failing rows. So a `relationships` test with more than 10 orphan rows escalates from `warn` to `error` and blocks the merge.
+
+### Singular tests in `tests/`
+
+Every singular test file declares severity at the top of the SQL:
+
+```sql
+{{ config(
+    severity='error',
+    tags=['data_quality'],
+    description='...'
+) }}
+```
+
+The `tags` field is conventional, not enforced — `data_quality`, `operations_alert`, and `fixture` are in current use.
+
+### Source freshness in `_sources.yml`
+
+```yaml
+freshness:
+  warn_after:
+    count: 24
+    period: hour
+  error_after:
+    count: 48
+    period: hour
+```
+
+Configured per source table. Currently uniform across all five sources.
+
+## How CI Interprets Severity
+
+- `dbt build` exits 0 if all tests pass or only warn, and non-zero if any test errors.
+- The `Build & Validate` CI job fails on non-zero `dbt build` exit, blocking merge.
+- Warnings appear in the `dbt build` output but do not fail the job.
+- The `dbt source freshness` step uses `continue-on-error: true` because synthetic data is always stale by definition — the step documents the freshness pattern without blocking CI.
+
+## Escalation Paths
+
+If a `warn`-severity test starts failing repeatedly:
+
+1. Investigate the underlying cause — does the model have a real bug, or is the threshold too tight?
+2. If the model is right and the threshold is wrong, tighten the threshold (raise `error_if`) and document in `decisions.md`.
+3. If the model is wrong, fix it. The warning becomes silent.
+4. Never simply suppress a warning by removing the test.
+
+If an `error`-severity test starts failing in CI:
+
+1. The PR is blocked. This is intentional.
+2. Determine whether the test is wrong (rare — would have caught it during review) or the model is wrong (almost always the case).
+3. Fix the underlying issue. Do not lower severity to ship.
+
+## See Also
+
+- [`docs/dbt-guidelines.md`](dbt-guidelines.md) — full dbt conventions including the test-category map.
+- [`tests/CLAUDE.md`](../tests/CLAUDE.md) — test directory charter.
+- [`decisions.md`](../decisions.md) — entries documenting severity changes over time.

--- a/models/marts/billing/_models.yml
+++ b/models/marts/billing/_models.yml
@@ -49,6 +49,10 @@ models:
               arguments:
                 to: ref('dim_users')
                 field: user_key
+              config:
+                severity: warn
+                warn_if: ">0"
+                error_if: ">10"
 
       - name: account_id
         data_type: string
@@ -65,6 +69,10 @@ models:
               arguments:
                 to: ref('dim_accounts')
                 field: account_key
+              config:
+                severity: warn
+                warn_if: ">0"
+                error_if: ">10"
 
       - name: event_date_key
         data_type: int64
@@ -75,6 +83,10 @@ models:
               arguments:
                 to: ref('dim_date')
                 field: date_key
+              config:
+                severity: warn
+                warn_if: ">0"
+                error_if: ">10"
 
       - name: event_time
         data_type: timestamp
@@ -207,6 +219,10 @@ models:
               arguments:
                 to: ref('dim_accounts')
                 field: account_key
+              config:
+                severity: warn
+                warn_if: ">0"
+                error_if: ">10"
 
       - name: subscription_event_id
         data_type: string
@@ -229,6 +245,10 @@ models:
               arguments:
                 to: ref('dim_date')
                 field: date_key
+              config:
+                severity: warn
+                warn_if: ">0"
+                error_if: ">10"
 
       - name: movement_date
         data_type: date
@@ -323,6 +343,10 @@ models:
               arguments:
                 to: ref('dim_users')
                 field: user_key
+              config:
+                severity: warn
+                warn_if: ">0"
+                error_if: ">10"
 
       - name: account_id
         data_type: string
@@ -339,6 +363,10 @@ models:
               arguments:
                 to: ref('dim_accounts')
                 field: account_key
+              config:
+                severity: warn
+                warn_if: ">0"
+                error_if: ">10"
 
       - name: issued_date_key
         data_type: int64
@@ -349,6 +377,10 @@ models:
               arguments:
                 to: ref('dim_date')
                 field: date_key
+              config:
+                severity: warn
+                warn_if: ">0"
+                error_if: ">10"
 
       - name: issued_at
         data_type: timestamp

--- a/models/marts/core/_models.yml
+++ b/models/marts/core/_models.yml
@@ -75,6 +75,10 @@ models:
               arguments:
                 to: ref('dim_channels')
                 field: channel_key
+              config:
+                severity: warn
+                warn_if: ">0"
+                error_if: ">10"
               where: "first_touch_channel_key is not null"
 
       - name: last_touch_channel_key
@@ -85,6 +89,10 @@ models:
               arguments:
                 to: ref('dim_channels')
                 field: channel_key
+              config:
+                severity: warn
+                warn_if: ">0"
+                error_if: ">10"
               where: "last_touch_channel_key is not null"
 
       - name: engagement_state
@@ -195,6 +203,10 @@ models:
               arguments:
                 to: ref('dim_channels')
                 field: channel_key
+              config:
+                severity: warn
+                warn_if: ">0"
+                error_if: ">10"
               where: "acquisition_channel_key is not null"
 
       - name: acquisition_date
@@ -256,6 +268,10 @@ models:
               arguments:
                 to: ref('dim_users')
                 field: user_key
+              config:
+                severity: warn
+                warn_if: ">0"
+                error_if: ">10"
 
       - name: signup_date_key
         data_type: int64
@@ -266,6 +282,10 @@ models:
               arguments:
                 to: ref('dim_date')
                 field: date_key
+              config:
+                severity: warn
+                warn_if: ">0"
+                error_if: ">10"
 
       - name: signup_at
         data_type: timestamp
@@ -300,6 +320,10 @@ models:
               arguments:
                 to: ref('dim_channels')
                 field: channel_key
+              config:
+                severity: warn
+                warn_if: ">0"
+                error_if: ">10"
 
       - name: platform
         data_type: string
@@ -365,6 +389,10 @@ models:
               arguments:
                 to: ref('dim_users')
                 field: user_key
+              config:
+                severity: warn
+                warn_if: ">0"
+                error_if: ">10"
 
       - name: activation_date_key
         data_type: int64
@@ -375,6 +403,10 @@ models:
               arguments:
                 to: ref('dim_date')
                 field: date_key
+              config:
+                severity: warn
+                warn_if: ">0"
+                error_if: ">10"
 
       - name: activation_at
         data_type: timestamp
@@ -391,6 +423,10 @@ models:
               arguments:
                 to: ref('dim_channels')
                 field: channel_key
+              config:
+                severity: warn
+                warn_if: ">0"
+                error_if: ">10"
 
       - name: last_touch_channel_key
         data_type: int64
@@ -401,6 +437,10 @@ models:
               arguments:
                 to: ref('dim_channels')
                 field: channel_key
+              config:
+                severity: warn
+                warn_if: ">0"
+                error_if: ">10"
 
       - name: first_touch_channel
         data_type: string
@@ -449,6 +489,10 @@ models:
               arguments:
                 to: ref('dim_date')
                 field: date_key
+              config:
+                severity: warn
+                warn_if: ">0"
+                error_if: ">10"
 
       - name: retention_period
         data_type: string
@@ -488,6 +532,10 @@ models:
               arguments:
                 to: ref('dim_date')
                 field: date_key
+              config:
+                severity: warn
+                warn_if: ">0"
+                error_if: ">10"
               where: "is_period_complete"
 
       - name: cohort_size

--- a/models/marts/marketing/_models.yml
+++ b/models/marts/marketing/_models.yml
@@ -37,6 +37,10 @@ models:
               arguments:
                 to: ref('dim_date')
                 field: date_key
+              config:
+                severity: warn
+                warn_if: ">0"
+                error_if: ">10"
 
       - name: channel
         data_type: string
@@ -53,6 +57,10 @@ models:
               arguments:
                 to: ref('dim_channels')
                 field: channel_key
+              config:
+                severity: warn
+                warn_if: ">0"
+                error_if: ">10"
 
       - name: campaign_id
         data_type: string

--- a/models/marts/product/_models.yml
+++ b/models/marts/product/_models.yml
@@ -37,6 +37,10 @@ models:
               arguments:
                 to: ref('dim_date')
                 field: date_key
+              config:
+                severity: warn
+                warn_if: ">0"
+                error_if: ">10"
 
       - name: platform
         data_type: string
@@ -155,6 +159,10 @@ models:
               arguments:
                 to: ref('dim_users')
                 field: user_key
+              config:
+                severity: warn
+                warn_if: ">0"
+                error_if: ">10"
 
       - name: user_id
         data_type: string
@@ -171,6 +179,10 @@ models:
               arguments:
                 to: ref('dim_experiments')
                 field: experiment_key
+              config:
+                severity: warn
+                warn_if: ">0"
+                error_if: ">10"
 
       - name: variant
         data_type: string
@@ -233,6 +245,10 @@ models:
               arguments:
                 to: ref('dim_users')
                 field: user_key
+              config:
+                severity: warn
+                warn_if: ">0"
+                error_if: ">10"
 
       - name: account_id
         data_type: string
@@ -246,6 +262,10 @@ models:
               arguments:
                 to: ref('dim_accounts')
                 field: account_key
+              config:
+                severity: warn
+                warn_if: ">0"
+                error_if: ">10"
               where: "account_key is not null"
 
       - name: usage_date_key
@@ -257,6 +277,10 @@ models:
               arguments:
                 to: ref('dim_date')
                 field: date_key
+              config:
+                severity: warn
+                warn_if: ">0"
+                error_if: ">10"
 
       - name: usage_at
         data_type: timestamp
@@ -318,6 +342,10 @@ models:
               arguments:
                 to: ref('dim_sessions')
                 field: session_key
+              config:
+                severity: warn
+                warn_if: ">0"
+                error_if: ">10"
 
       - name: session_id
         data_type: string
@@ -338,6 +366,10 @@ models:
               arguments:
                 to: ref('dim_users')
                 field: user_key
+              config:
+                severity: warn
+                warn_if: ">0"
+                error_if: ">10"
               where: "user_key is not null"
 
       - name: session_date_key
@@ -349,6 +381,10 @@ models:
               arguments:
                 to: ref('dim_date')
                 field: date_key
+              config:
+                severity: warn
+                warn_if: ">0"
+                error_if: ">10"
 
       - name: session_start_at
         data_type: timestamp
@@ -430,6 +466,10 @@ models:
               arguments:
                 to: ref('dim_users')
                 field: user_key
+              config:
+                severity: warn
+                warn_if: ">0"
+                error_if: ">10"
 
       - name: experiment_id
         data_type: string
@@ -446,6 +486,10 @@ models:
               arguments:
                 to: ref('dim_experiments')
                 field: experiment_key
+              config:
+                severity: warn
+                warn_if: ">0"
+                error_if: ">10"
 
       - name: variant
         data_type: string
@@ -473,6 +517,10 @@ models:
               arguments:
                 to: ref('dim_date')
                 field: date_key
+              config:
+                severity: warn
+                warn_if: ">0"
+                error_if: ">10"
 
       - name: converted
         data_type: boolean

--- a/models/marts/support/_models.yml
+++ b/models/marts/support/_models.yml
@@ -43,6 +43,10 @@ models:
               arguments:
                 to: ref('dim_users')
                 field: user_key
+              config:
+                severity: warn
+                warn_if: ">0"
+                error_if: ">10"
 
       - name: account_id
         data_type: string
@@ -59,6 +63,10 @@ models:
               arguments:
                 to: ref('dim_accounts')
                 field: account_key
+              config:
+                severity: warn
+                warn_if: ">0"
+                error_if: ">10"
 
       - name: created_date_key
         data_type: int64
@@ -69,6 +77,10 @@ models:
               arguments:
                 to: ref('dim_date')
                 field: date_key
+              config:
+                severity: warn
+                warn_if: ">0"
+                error_if: ">10"
 
       - name: created_at
         data_type: timestamp


### PR DESCRIPTION
## Summary

Closes the last unblocked sub-issue of the foundation epic: agentic-hub#305.

### Problem

All 37 \`relationships:\` tests across the marts inherited dbt's default severity (\`error\`), meaning a single orphan row blocked merge. Right for PKs and enums, too strict for FKs — small referential gaps from late-arriving anonymous events are tolerable while large gaps signal real upstream breaks.

### Changes

**Mart YAMLs (37 tests across 5 files)** — added explicit \`config:\` block:

\`\`\`yaml
- relationships:
    arguments:
      to: ref('dim_users')
      field: user_key
    config:
      severity: warn
      warn_if: \">0\"
      error_if: \">10\"
\`\`\`

Behaviour: 1–10 orphan rows → warning (CI green), 11+ → error (blocks merge).

**\`docs/quality-gates.md\`** — rewritten as a formal severity-and-thresholds policy with per-category rationale, configuration-site reference, CI interpretation, and escalation paths.

**\`decisions.md\`** — new 2026-05-11 entry documenting the policy and the decision to keep source freshness at 24h/48h vs the original orchestration spec's 12h/24h.

### What's not changed

PK / enum / invariant / reconciliation / fanout / contract test severities remain \`error\` — now explicitly documented as such, but no behaviour change.

### Validation

- All 5 \`_models.yml\` files parse as valid YAML (verified with PyYAML).
- Edit was programmatic (single Python regex pass) so all 37 tests got identical config blocks at the right indentation.
- Should pass CI without any model-side changes.