### PR TITLE
fix: parse before docs generate; verify artifacts

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -67,12 +67,24 @@ jobs:
           mkdir -p ~/.dbt
           cp profiles.yml.example ~/.dbt/profiles.yml
 
+      - name: Parse project (writes target/manifest.json)
+        # `dbt docs generate --no-compile` does NOT write a manifest — it expects
+        # one to exist already. Without an explicit parse, the next step succeeds
+        # (writes catalog.json) but the staging step then can't find manifest.json.
+        run: dbt parse --target dev
+
       - name: Generate dbt docs (no compile, empty catalog — no BQ connection)
-        # --no-compile   : skip query compilation (manifest already covers structure)
+        # --no-compile   : skip query compilation (manifest from prior parse covers structure)
         # --empty-catalog: skip the catalog query that requires a live BQ connection
         # Net result: rendered site has model graph, descriptions, tests, and lineage,
         # but no BQ-derived column types or row counts. Acceptable for a portfolio piece.
         run: dbt docs generate --no-compile --empty-catalog --target dev
+
+      - name: Verify expected artifacts (fail fast if dbt didn't write them)
+        run: |
+          ls -la target/
+          test -f target/manifest.json || { echo "manifest.json missing"; exit 1; }
+          test -f target/index.html || { echo "index.html missing"; exit 1; }
 
       - name: Stage docs site
         run: |


### PR DESCRIPTION
## Summary

Second docs deploy attempt failed differently than the first. \`dbt docs generate --no-compile\` doesn't write a manifest — it expects one to exist already from a prior parse or build. The first run wrote \`catalog.json\` successfully but the staging step then errored on missing \`manifest.json\`.

## Fix

1. **Add explicit \`dbt parse --target dev\`** before \`dbt docs generate\`. This writes the manifest the docs command consumes.
2. **Add a \"Verify expected artifacts\" step** that lists \`target/\` and fails fast if manifest.json or index.html is missing. Surfaces the next silent failure mode if dbt's behaviour changes again.

No behaviour change for the deployed site — same model graph, descriptions, tests, lineage. Just makes the workflow actually produce those artifacts.

## Run history (this is the second of two docs-deploy fixes)

| Run | Failure | Fix |
|---|---|---|
| `25691234398` | \`AttributeError: 'NoneType' has no attribute 'close'\` (BQ connection during catalog) | #93 — \`--empty-catalog\` flag |
| `25692901984` | \`cp: cannot stat 'target/manifest.json'\` | This PR — explicit \`dbt parse\` |