### PR TITLE
feat: Lightdash meta annotations on all 17 mart models (closes #393 dbt-side)

### DIFF
--- a/decisions.md
+++ b/decisions.md
@@ -219,3 +219,22 @@
 - Expanded `docs/quality-gates.md` into a formal severity-and-thresholds policy: per-category rationale, configuration-site reference, escalation paths, and explicit documentation of CI's interpretation of severity
 - Documented the source freshness deviation from the original orchestration spec (24h/48h vs 12h/24h): synthetic data is always stale; tightening freshness adds no signal
 - No changes to PK/enum/invariant/reconciliation/fanout/contract test severities — those remain `error` (documented as such, not changed)
+
+## 2026-05-11: Lightdash semantic annotations on mart models
+**Why:** Lightdash discovers explores by reading `meta.dimension` and `meta.metric` from each column's manifest entry. Without these, every mart shows up in Lightdash as an opaque table with no curated dimensions or metrics. This is the dbt-side half of agentic-hub#393.
+**What changed:**
+- Added column-level `meta.dimension` block to all 198 columns across the 17 mart models
+- Annotation rules applied programmatically by column name + data_type:
+  - `*_key` (INT64 surrogate) → `hidden: true` (joinable, not visible)
+  - `*_id` (STRING natural key) → `hidden: true` (joinable, not visible)
+  - `*_date` (DATE) → `type: date` with `time_intervals: [DAY, WEEK, MONTH, QUARTER, YEAR]`
+  - `*_at` / `*_time` (TIMESTAMP) → `type: timestamp` with same intervals
+  - `is_*` / `has_*` / `was_*` (BOOL) → `type: boolean`
+  - Other STRING → `type: string`
+  - Other numeric → `type: number`
+- Added column-level `meta.metric` block on 23 high-value metric columns across 11 marts. Each carries `type` (sum / count_distinct / average), a human-readable `label`, and a `description`. Reflects the canonical metrics from `docs/metric-contract.md` — no new business semantics introduced; Lightdash surfaces what dbt already defines.
+- Did NOT alter the existing model-level `meta` block (owner, pii, sla, tier) — Lightdash reads those too but they were already in place.
+
+**Trade-offs considered:**
+- Could have used `config.meta` at column level (matching the model-level pattern) instead of top-level `meta`. Chose top-level because Lightdash's documented examples use that form and both are valid in dbt 1.11.
+- Could have added explicit model-level `meta.label` / `meta.group_label` on every fact. Skipped — Lightdash derives a sensible default from the model name. Adding labels is cheap follow-up if needed.

--- a/models/marts/billing/_models.yml
+++ b/models/marts/billing/_models.yml
@@ -17,6 +17,9 @@ models:
       - name: subscription_event_key
         data_type: int64
         description: '{{ doc("col_subscription_event_key") }}'
+        meta:
+          dimension:
+            hidden: true
         data_tests:
           - unique
           - not_null
@@ -24,6 +27,9 @@ models:
       - name: subscription_event_id
         data_type: string
         description: '{{ doc("col_subscription_event_id") }}'
+        meta:
+          dimension:
+            hidden: true
         data_tests:
           - unique
           - not_null
@@ -31,18 +37,27 @@ models:
       - name: subscription_id
         data_type: string
         description: '{{ doc("col_subscription_id") }}'
+        meta:
+          dimension:
+            hidden: true
         data_tests:
           - not_null
 
       - name: user_id
         data_type: string
         description: '{{ doc("col_user_id") }}'
+        meta:
+          dimension:
+            hidden: true
         data_tests:
           - not_null
 
       - name: user_key
         data_type: int64
         description: '{{ doc("col_user_key") }}'
+        meta:
+          dimension:
+            hidden: true
         data_tests:
           - not_null
           - relationships:
@@ -57,12 +72,18 @@ models:
       - name: account_id
         data_type: string
         description: '{{ doc("col_account_id") }}'
+        meta:
+          dimension:
+            hidden: true
         data_tests:
           - not_null
 
       - name: account_key
         data_type: int64
         description: '{{ doc("col_account_key") }}'
+        meta:
+          dimension:
+            hidden: true
         data_tests:
           - not_null
           - relationships:
@@ -77,6 +98,9 @@ models:
       - name: event_date_key
         data_type: int64
         description: '{{ doc("col_event_date_key") }}'
+        meta:
+          dimension:
+            hidden: true
         data_tests:
           - not_null
           - relationships:
@@ -91,12 +115,19 @@ models:
       - name: event_time
         data_type: timestamp
         description: '{{ doc("col_event_time") }}'
+        meta:
+          dimension:
+            type: timestamp
+            time_intervals: ["DAY", "WEEK", "MONTH", "QUARTER", "YEAR"]
         data_tests:
           - not_null
 
       - name: event_type
         data_type: string
         description: '{{ doc("col_event_type") }}'
+        meta:
+          dimension:
+            type: string
         data_tests:
           - not_null
           - accepted_values:
@@ -114,6 +145,9 @@ models:
       - name: plan
         data_type: string
         description: '{{ doc("col_plan") }}'
+        meta:
+          dimension:
+            type: string
         data_tests:
           - not_null
           - accepted_values:
@@ -127,6 +161,9 @@ models:
       - name: previous_plan
         data_type: string
         description: '{{ doc("col_previous_plan") }}'
+        meta:
+          dimension:
+            type: string
         data_tests:
           - accepted_values:
               arguments:
@@ -141,6 +178,9 @@ models:
       - name: billing_cycle
         data_type: string
         description: '{{ doc("col_billing_cycle") }}'
+        meta:
+          dimension:
+            type: string
         data_tests:
           - not_null
           - accepted_values:
@@ -152,12 +192,22 @@ models:
       - name: mrr_amount
         data_type: numeric
         description: '{{ doc("col_mrr_amount") }}'
+        meta:
+          dimension:
+            type: number
+          metric:
+            type: sum
+            label: "Subscription MRR"
+            description: 'Sum of MRR amounts at subscription event time.'
         data_tests:
           - not_null
 
       - name: currency
         data_type: string
         description: '{{ doc("col_currency") }}'
+        meta:
+          dimension:
+            type: string
         data_tests:
           - not_null
           - accepted_values:
@@ -169,20 +219,32 @@ models:
       - name: cancel_reason
         data_type: string
         description: '{{ doc("col_cancel_reason") }}'
+        meta:
+          dimension:
+            type: string
 
       - name: is_voluntary
         data_type: boolean
         description: '{{ doc("col_is_voluntary") }}'
+        meta:
+          dimension:
+            type: boolean
 
       - name: is_active
         data_type: boolean
         description: '{{ doc("col_is_active") }}'
+        meta:
+          dimension:
+            type: boolean
         data_tests:
           - not_null
 
       - name: days_since_previous_event
         data_type: int64
         description: '{{ doc("col_days_since_previous_event") }}'
+        meta:
+          dimension:
+            type: number
 
   - name: fct_mrr_movements
     description: '{{ doc("fct_mrr_movements") }}'
@@ -200,6 +262,9 @@ models:
       - name: mrr_movement_key
         data_type: int64
         description: '{{ doc("col_mrr_movement_key") }}'
+        meta:
+          dimension:
+            hidden: true
         data_tests:
           - unique
           - not_null
@@ -207,12 +272,18 @@ models:
       - name: account_id
         data_type: string
         description: '{{ doc("col_account_id") }}'
+        meta:
+          dimension:
+            hidden: true
         data_tests:
           - not_null
 
       - name: account_key
         data_type: int64
         description: '{{ doc("col_account_key") }}'
+        meta:
+          dimension:
+            hidden: true
         data_tests:
           - not_null
           - relationships:
@@ -227,18 +298,27 @@ models:
       - name: subscription_event_id
         data_type: string
         description: '{{ doc("col_subscription_event_id") }}'
+        meta:
+          dimension:
+            hidden: true
         data_tests:
           - not_null
 
       - name: subscription_id
         data_type: string
         description: '{{ doc("col_subscription_id") }}'
+        meta:
+          dimension:
+            hidden: true
         data_tests:
           - not_null
 
       - name: movement_date_key
         data_type: int64
         description: '{{ doc("col_movement_date_key") }}'
+        meta:
+          dimension:
+            hidden: true
         data_tests:
           - not_null
           - relationships:
@@ -253,12 +333,19 @@ models:
       - name: movement_date
         data_type: date
         description: '{{ doc("col_movement_date") }}'
+        meta:
+          dimension:
+            type: date
+            time_intervals: ["DAY", "WEEK", "MONTH", "QUARTER", "YEAR"]
         data_tests:
           - not_null
 
       - name: movement_type
         data_type: string
         description: '{{ doc("col_movement_type") }}'
+        meta:
+          dimension:
+            type: string
         data_tests:
           - not_null
           - accepted_values:
@@ -273,18 +360,31 @@ models:
       - name: mrr_before
         data_type: numeric
         description: '{{ doc("col_mrr_before") }}'
+        meta:
+          dimension:
+            type: number
         data_tests:
           - not_null
 
       - name: mrr_after
         data_type: numeric
         description: '{{ doc("col_mrr_after") }}'
+        meta:
+          dimension:
+            type: number
         data_tests:
           - not_null
 
       - name: mrr_delta
         data_type: numeric
         description: '{{ doc("col_mrr_delta") }}'
+        meta:
+          dimension:
+            type: number
+          metric:
+            type: sum
+            label: "Net MRR"
+            description: 'Cumulative sum of MRR movements. Decomposes into new / expansion / contraction / churn / reactivation via the movement_type dimension.'
         data_tests:
           - not_null
 
@@ -311,6 +411,13 @@ models:
       - name: invoice_key
         data_type: int64
         description: '{{ doc("col_invoice_key") }}'
+        meta:
+          dimension:
+            hidden: true
+          metric:
+            type: count_distinct
+            label: "Invoices"
+            description: 'Distinct invoices issued.'
         data_tests:
           - unique
           - not_null
@@ -318,6 +425,9 @@ models:
       - name: invoice_id
         data_type: string
         description: '{{ doc("col_invoice_id") }}'
+        meta:
+          dimension:
+            hidden: true
         data_tests:
           - unique
           - not_null
@@ -325,18 +435,27 @@ models:
       - name: subscription_id
         data_type: string
         description: '{{ doc("col_subscription_id") }}'
+        meta:
+          dimension:
+            hidden: true
         data_tests:
           - not_null
 
       - name: user_id
         data_type: string
         description: '{{ doc("col_user_id") }}'
+        meta:
+          dimension:
+            hidden: true
         data_tests:
           - not_null
 
       - name: user_key
         data_type: int64
         description: '{{ doc("col_user_key") }}'
+        meta:
+          dimension:
+            hidden: true
         data_tests:
           - not_null
           - relationships:
@@ -351,12 +470,18 @@ models:
       - name: account_id
         data_type: string
         description: '{{ doc("col_account_id") }}'
+        meta:
+          dimension:
+            hidden: true
         data_tests:
           - not_null
 
       - name: account_key
         data_type: int64
         description: '{{ doc("col_account_key") }}'
+        meta:
+          dimension:
+            hidden: true
         data_tests:
           - not_null
           - relationships:
@@ -371,6 +496,9 @@ models:
       - name: issued_date_key
         data_type: int64
         description: '{{ doc("col_issued_date_key") }}'
+        meta:
+          dimension:
+            hidden: true
         data_tests:
           - not_null
           - relationships:
@@ -385,22 +513,40 @@ models:
       - name: issued_at
         data_type: timestamp
         description: '{{ doc("col_issued_at") }}'
+        meta:
+          dimension:
+            type: timestamp
+            time_intervals: ["DAY", "WEEK", "MONTH", "QUARTER", "YEAR"]
         data_tests:
           - not_null
 
       - name: paid_at
         data_type: timestamp
         description: '{{ doc("col_paid_at") }}'
+        meta:
+          dimension:
+            type: timestamp
+            time_intervals: ["DAY", "WEEK", "MONTH", "QUARTER", "YEAR"]
 
       - name: amount
         data_type: numeric
         description: '{{ doc("col_amount") }}'
+        meta:
+          dimension:
+            type: number
+          metric:
+            type: sum
+            label: "Invoice Amount"
+            description: 'Sum of invoice amounts billed.'
         data_tests:
           - not_null
 
       - name: currency
         data_type: string
         description: '{{ doc("col_currency") }}'
+        meta:
+          dimension:
+            type: string
         data_tests:
           - not_null
           - accepted_values:
@@ -412,6 +558,9 @@ models:
       - name: status
         data_type: string
         description: '{{ doc("col_invoice_status") }}'
+        meta:
+          dimension:
+            type: string
         data_tests:
           - not_null
           - accepted_values:
@@ -425,17 +574,30 @@ models:
       - name: refund_amount
         data_type: numeric
         description: '{{ doc("col_refund_amount") }}'
+        meta:
+          dimension:
+            type: number
         data_tests:
           - not_null
 
       - name: net_amount
         data_type: numeric
         description: '{{ doc("col_net_amount") }}'
+        meta:
+          dimension:
+            type: number
+          metric:
+            type: sum
+            label: "Net Revenue"
+            description: 'Sum of net amounts (amount minus refunds). Excludes refunded invoices.'
         data_tests:
           - not_null
 
       - name: is_paid
         data_type: boolean
         description: '{{ doc("col_is_paid") }}'
+        meta:
+          dimension:
+            type: boolean
         data_tests:
           - not_null

--- a/models/marts/core/_models.yml
+++ b/models/marts/core/_models.yml
@@ -17,6 +17,9 @@ models:
       - name: channel_key
         data_type: int64
         description: '{{ doc("col_channel_key") }}'
+        meta:
+          dimension:
+            hidden: true
         data_tests:
           - unique
           - not_null
@@ -24,6 +27,9 @@ models:
       - name: channel
         data_type: string
         description: '{{ doc("col_channel") }}'
+        meta:
+          dimension:
+            type: string
         data_tests:
           - unique
           - not_null
@@ -44,6 +50,9 @@ models:
       - name: user_key
         data_type: int64
         description: '{{ doc("col_user_key") }}'
+        meta:
+          dimension:
+            hidden: true
         data_tests:
           - unique
           - not_null
@@ -51,6 +60,9 @@ models:
       - name: user_id
         data_type: string
         description: '{{ doc("col_user_id") }}'
+        meta:
+          dimension:
+            hidden: true
         data_tests:
           - unique
           - not_null
@@ -58,18 +70,32 @@ models:
       - name: account_id
         data_type: string
         description: '{{ doc("col_account_id") }}'
+        meta:
+          dimension:
+            hidden: true
 
       - name: signup_at
         data_type: timestamp
         description: '{{ doc("col_signup_at") }}'
+        meta:
+          dimension:
+            type: timestamp
+            time_intervals: ["DAY", "WEEK", "MONTH", "QUARTER", "YEAR"]
 
       - name: activation_at
         data_type: timestamp
         description: '{{ doc("col_activation_at") }}'
+        meta:
+          dimension:
+            type: timestamp
+            time_intervals: ["DAY", "WEEK", "MONTH", "QUARTER", "YEAR"]
 
       - name: first_touch_channel_key
         data_type: int64
         description: '{{ doc("col_first_touch_channel_key") }}'
+        meta:
+          dimension:
+            hidden: true
         data_tests:
           - relationships:
               arguments:
@@ -84,6 +110,9 @@ models:
       - name: last_touch_channel_key
         data_type: int64
         description: '{{ doc("col_last_touch_channel_key") }}'
+        meta:
+          dimension:
+            hidden: true
         data_tests:
           - relationships:
               arguments:
@@ -98,6 +127,9 @@ models:
       - name: engagement_state
         data_type: string
         description: '{{ doc("col_engagement_state") }}'
+        meta:
+          dimension:
+            type: string
         data_tests:
           - not_null
           - accepted_values:
@@ -111,24 +143,36 @@ models:
       - name: is_re_engaged
         data_type: boolean
         description: '{{ doc("col_is_re_engaged") }}'
+        meta:
+          dimension:
+            type: boolean
         data_tests:
           - not_null
 
       - name: is_product_user
         data_type: boolean
         description: '{{ doc("col_is_product_user") }}'
+        meta:
+          dimension:
+            type: boolean
         data_tests:
           - not_null
 
       - name: is_billing_user
         data_type: boolean
         description: '{{ doc("col_is_billing_user") }}'
+        meta:
+          dimension:
+            type: boolean
         data_tests:
           - not_null
 
       - name: is_support_user
         data_type: boolean
         description: '{{ doc("col_is_support_user") }}'
+        meta:
+          dimension:
+            type: boolean
         data_tests:
           - not_null
 
@@ -148,6 +192,9 @@ models:
       - name: account_key
         data_type: int64
         description: '{{ doc("col_account_key") }}'
+        meta:
+          dimension:
+            hidden: true
         data_tests:
           - unique
           - not_null
@@ -155,6 +202,9 @@ models:
       - name: account_id
         data_type: string
         description: '{{ doc("col_account_id") }}'
+        meta:
+          dimension:
+            hidden: true
         data_tests:
           - unique
           - not_null
@@ -162,42 +212,84 @@ models:
       - name: plan
         data_type: string
         description: '{{ doc("col_plan") }}'
+        meta:
+          dimension:
+            type: string
 
       - name: billing_cycle
         data_type: string
         description: '{{ doc("col_billing_cycle") }}'
+        meta:
+          dimension:
+            type: string
 
       - name: mrr_amount
         data_type: numeric
         description: '{{ doc("col_mrr_amount") }}'
+        meta:
+          dimension:
+            type: number
+          metric:
+            type: sum
+            label: "Total MRR"
+            description: 'Sum of MRR across all accounts.'
 
       - name: currency
         data_type: string
         description: '{{ doc("col_currency") }}'
+        meta:
+          dimension:
+            type: string
 
       - name: user_count
         data_type: int64
         description: '{{ doc("col_user_count") }}'
+        meta:
+          dimension:
+            type: number
+          metric:
+            type: sum
+            label: "Total Users"
+            description: 'Sum of users across accounts.'
 
       - name: health_score
         data_type: float64
         description: '{{ doc("col_health_score") }}'
+        meta:
+          dimension:
+            type: number
+          metric:
+            type: average
+            label: "Avg Health Score"
+            description: 'Mean account health score (0–100).'
 
       - name: activity_score
         data_type: float64
         description: '{{ doc("col_activity_score") }}'
+        meta:
+          dimension:
+            type: number
 
       - name: billing_score
         data_type: float64
         description: '{{ doc("col_billing_score") }}'
+        meta:
+          dimension:
+            type: number
 
       - name: support_score
         data_type: float64
         description: '{{ doc("col_support_score") }}'
+        meta:
+          dimension:
+            type: number
 
       - name: acquisition_channel_key
         data_type: int64
         description: '{{ doc("col_acquisition_channel_key") }}'
+        meta:
+          dimension:
+            hidden: true
         data_tests:
           - relationships:
               arguments:
@@ -212,10 +304,17 @@ models:
       - name: acquisition_date
         data_type: date
         description: '{{ doc("col_acquisition_date") }}'
+        meta:
+          dimension:
+            type: date
+            time_intervals: ["DAY", "WEEK", "MONTH", "QUARTER", "YEAR"]
 
       - name: lifecycle_stage
         data_type: string
         description: '{{ doc("col_lifecycle_stage") }}'
+        meta:
+          dimension:
+            type: string
         data_tests:
           - accepted_values:
               arguments:
@@ -242,6 +341,13 @@ models:
       - name: signup_key
         data_type: int64
         description: '{{ doc("col_signup_key") }}'
+        meta:
+          dimension:
+            hidden: true
+          metric:
+            type: count_distinct
+            label: "Signups"
+            description: 'Distinct signup events.'
         data_tests:
           - unique
           - not_null
@@ -249,6 +355,9 @@ models:
       - name: event_id
         data_type: string
         description: '{{ doc("col_event_id") }}'
+        meta:
+          dimension:
+            hidden: true
         data_tests:
           - unique
           - not_null
@@ -256,12 +365,18 @@ models:
       - name: user_id
         data_type: string
         description: '{{ doc("col_user_id") }}'
+        meta:
+          dimension:
+            hidden: true
         data_tests:
           - not_null
 
       - name: user_key
         data_type: int64
         description: '{{ doc("col_user_key") }}'
+        meta:
+          dimension:
+            hidden: true
         data_tests:
           - not_null
           - relationships:
@@ -276,6 +391,9 @@ models:
       - name: signup_date_key
         data_type: int64
         description: '{{ doc("col_signup_date_key") }}'
+        meta:
+          dimension:
+            hidden: true
         data_tests:
           - not_null
           - relationships:
@@ -290,12 +408,19 @@ models:
       - name: signup_at
         data_type: timestamp
         description: '{{ doc("col_signup_at") }}'
+        meta:
+          dimension:
+            type: timestamp
+            time_intervals: ["DAY", "WEEK", "MONTH", "QUARTER", "YEAR"]
         data_tests:
           - not_null
 
       - name: signup_method
         data_type: string
         description: '{{ doc("col_signup_method") }}'
+        meta:
+          dimension:
+            type: string
         data_tests:
           - not_null
           - accepted_values:
@@ -308,12 +433,18 @@ models:
       - name: channel
         data_type: string
         description: '{{ doc("col_channel") }}'
+        meta:
+          dimension:
+            type: string
         data_tests:
           - not_null
 
       - name: channel_key
         data_type: int64
         description: '{{ doc("col_channel_key") }}'
+        meta:
+          dimension:
+            hidden: true
         data_tests:
           - not_null
           - relationships:
@@ -328,26 +459,44 @@ models:
       - name: platform
         data_type: string
         description: '{{ doc("col_platform") }}'
+        meta:
+          dimension:
+            type: string
 
       - name: device_type
         data_type: string
         description: '{{ doc("col_device_type") }}'
+        meta:
+          dimension:
+            type: string
 
       - name: browser
         data_type: string
         description: '{{ doc("col_browser") }}'
+        meta:
+          dimension:
+            type: string
 
       - name: utm_source
         data_type: string
         description: '{{ doc("col_utm_source") }}'
+        meta:
+          dimension:
+            type: string
 
       - name: utm_medium
         data_type: string
         description: '{{ doc("col_utm_medium") }}'
+        meta:
+          dimension:
+            type: string
 
       - name: utm_campaign
         data_type: string
         description: '{{ doc("col_utm_campaign") }}'
+        meta:
+          dimension:
+            type: string
 
   - name: fct_activations
     description: '{{ doc("fct_activations") }}'
@@ -365,6 +514,13 @@ models:
       - name: activation_key
         data_type: int64
         description: '{{ doc("col_activation_key") }}'
+        meta:
+          dimension:
+            hidden: true
+          metric:
+            type: count_distinct
+            label: "Activations"
+            description: 'Distinct activation events — users who completed an activation action within the window.'
         data_tests:
           - unique
           - not_null
@@ -372,6 +528,9 @@ models:
       - name: user_id
         data_type: string
         description: '{{ doc("col_user_id") }}'
+        meta:
+          dimension:
+            hidden: true
         data_tests:
           # unique is correct: int_attribution produces exactly one row per user
           # (one-activation-per-user is the business invariant). activation_key
@@ -383,6 +542,9 @@ models:
       - name: user_key
         data_type: int64
         description: '{{ doc("col_user_key") }}'
+        meta:
+          dimension:
+            hidden: true
         data_tests:
           - not_null
           - relationships:
@@ -397,6 +559,9 @@ models:
       - name: activation_date_key
         data_type: int64
         description: '{{ doc("col_activation_date_key") }}'
+        meta:
+          dimension:
+            hidden: true
         data_tests:
           - not_null
           - relationships:
@@ -411,12 +576,19 @@ models:
       - name: activation_at
         data_type: timestamp
         description: '{{ doc("col_activation_at") }}'
+        meta:
+          dimension:
+            type: timestamp
+            time_intervals: ["DAY", "WEEK", "MONTH", "QUARTER", "YEAR"]
         data_tests:
           - not_null
 
       - name: first_touch_channel_key
         data_type: int64
         description: '{{ doc("col_first_touch_channel_key") }}'
+        meta:
+          dimension:
+            hidden: true
         data_tests:
           - not_null
           - relationships:
@@ -431,6 +603,9 @@ models:
       - name: last_touch_channel_key
         data_type: int64
         description: '{{ doc("col_last_touch_channel_key") }}'
+        meta:
+          dimension:
+            hidden: true
         data_tests:
           - not_null
           - relationships:
@@ -445,12 +620,18 @@ models:
       - name: first_touch_channel
         data_type: string
         description: '{{ doc("col_first_touch_channel") }}'
+        meta:
+          dimension:
+            type: string
         data_tests:
           - not_null
 
       - name: last_touch_channel
         data_type: string
         description: '{{ doc("col_last_touch_channel") }}'
+        meta:
+          dimension:
+            type: string
         data_tests:
           - not_null
 
@@ -470,6 +651,9 @@ models:
       - name: retention_cohort_key
         data_type: int64
         description: '{{ doc("col_retention_cohort_key") }}'
+        meta:
+          dimension:
+            hidden: true
         data_tests:
           - unique
           - not_null
@@ -477,12 +661,19 @@ models:
       - name: cohort_week_start_date
         data_type: date
         description: '{{ doc("col_cohort_week_start_date") }}'
+        meta:
+          dimension:
+            type: date
+            time_intervals: ["DAY", "WEEK", "MONTH", "QUARTER", "YEAR"]
         data_tests:
           - not_null
 
       - name: cohort_week_date_key
         data_type: int64
         description: '{{ doc("col_cohort_week_date_key") }}'
+        meta:
+          dimension:
+            hidden: true
         data_tests:
           - not_null
           - relationships:
@@ -497,6 +688,9 @@ models:
       - name: retention_period
         data_type: string
         description: '{{ doc("col_retention_period") }}'
+        meta:
+          dimension:
+            type: string
         data_tests:
           - not_null
           - accepted_values:
@@ -514,18 +708,28 @@ models:
       - name: period_offset_days
         data_type: int64
         description: '{{ doc("col_period_offset_days") }}'
+        meta:
+          dimension:
+            type: number
         data_tests:
           - not_null
 
       - name: period_end_date
         data_type: date
         description: '{{ doc("col_period_end_date") }}'
+        meta:
+          dimension:
+            type: date
+            time_intervals: ["DAY", "WEEK", "MONTH", "QUARTER", "YEAR"]
         data_tests:
           - not_null
 
       - name: period_end_date_key
         data_type: int64
         description: '{{ doc("col_period_end_date_key") }}'
+        meta:
+          dimension:
+            hidden: true
         data_tests:
           - not_null
           - relationships:
@@ -541,24 +745,48 @@ models:
       - name: cohort_size
         data_type: int64
         description: '{{ doc("col_cohort_size") }}'
+        meta:
+          dimension:
+            type: number
+          metric:
+            type: sum
+            label: "Cohort Size"
+            description: 'Sum of users in each cohort window.'
         data_tests:
           - not_null
 
       - name: retained_count
         data_type: int64
         description: '{{ doc("col_retained_count") }}'
+        meta:
+          dimension:
+            type: number
+          metric:
+            type: sum
+            label: "Retained Users"
+            description: 'Sum of users retained at each period.'
         data_tests:
           - not_null
 
       - name: retention_rate
         data_type: float64
         description: '{{ doc("col_retention_rate") }}'
+        meta:
+          dimension:
+            type: number
+          metric:
+            type: average
+            label: "Retention Rate"
+            description: 'Mean retention rate across cohorts. Note: cohort_size-weighted mean is preferred for executive reporting.'
         data_tests:
           - not_null
 
       - name: is_period_complete
         data_type: boolean
         description: '{{ doc("col_is_period_complete") }}'
+        meta:
+          dimension:
+            type: boolean
         data_tests:
           - not_null
 

--- a/models/marts/marketing/_models.yml
+++ b/models/marts/marketing/_models.yml
@@ -17,6 +17,9 @@ models:
       - name: spend_key
         data_type: int64
         description: '{{ doc("col_spend_key") }}'
+        meta:
+          dimension:
+            hidden: true
         data_tests:
           - unique
           - not_null
@@ -24,6 +27,9 @@ models:
       - name: spend_id
         data_type: string
         description: '{{ doc("col_spend_id") }}'
+        meta:
+          dimension:
+            hidden: true
         data_tests:
           - unique
           - not_null
@@ -31,6 +37,9 @@ models:
       - name: spend_date_key
         data_type: int64
         description: '{{ doc("col_spend_date_key") }}'
+        meta:
+          dimension:
+            hidden: true
         data_tests:
           - not_null
           - relationships:
@@ -45,12 +54,18 @@ models:
       - name: channel
         data_type: string
         description: '{{ doc("col_channel") }}'
+        meta:
+          dimension:
+            type: string
         data_tests:
           - not_null
 
       - name: channel_key
         data_type: int64
         description: '{{ doc("col_channel_key") }}'
+        meta:
+          dimension:
+            hidden: true
         data_tests:
           - not_null
           - relationships:
@@ -65,29 +80,59 @@ models:
       - name: campaign_id
         data_type: string
         description: '{{ doc("col_campaign_id") }}'
+        meta:
+          dimension:
+            hidden: true
         data_tests:
           - not_null
 
       - name: campaign_name
         data_type: string
         description: '{{ doc("col_campaign_name") }}'
+        meta:
+          dimension:
+            type: string
 
       - name: spend_amount
         data_type: numeric
         description: '{{ doc("col_spend_amount") }}'
+        meta:
+          dimension:
+            type: number
+          metric:
+            type: sum
+            label: "Marketing Spend"
+            description: 'Sum of marketing spend.'
         data_tests:
           - not_null
 
       - name: currency
         data_type: string
         description: '{{ doc("col_currency") }}'
+        meta:
+          dimension:
+            type: string
         data_tests:
           - not_null
 
       - name: impressions
         data_type: int64
         description: '{{ doc("col_impressions") }}'
+        meta:
+          dimension:
+            type: number
+          metric:
+            type: sum
+            label: "Impressions"
+            description: 'Sum of ad impressions.'
 
       - name: clicks
         data_type: int64
         description: '{{ doc("col_clicks") }}'
+        meta:
+          dimension:
+            type: number
+          metric:
+            type: sum
+            label: "Clicks"
+            description: 'Sum of ad clicks.'

--- a/models/marts/product/_models.yml
+++ b/models/marts/product/_models.yml
@@ -17,6 +17,9 @@ models:
       - name: session_key
         data_type: int64
         description: '{{ doc("col_session_key") }}'
+        meta:
+          dimension:
+            hidden: true
         data_tests:
           - unique
           - not_null
@@ -24,6 +27,9 @@ models:
       - name: session_id
         data_type: string
         description: '{{ doc("col_session_id") }}'
+        meta:
+          dimension:
+            hidden: true
         data_tests:
           - unique
           - not_null
@@ -31,6 +37,9 @@ models:
       - name: session_date_key
         data_type: int64
         description: '{{ doc("col_session_date_key") }}'
+        meta:
+          dimension:
+            hidden: true
         data_tests:
           - not_null
           - relationships:
@@ -45,38 +54,65 @@ models:
       - name: platform
         data_type: string
         description: '{{ doc("col_platform") }}'
+        meta:
+          dimension:
+            type: string
 
       - name: device_type
         data_type: string
         description: '{{ doc("col_device_type") }}'
+        meta:
+          dimension:
+            type: string
 
       - name: browser
         data_type: string
         description: '{{ doc("col_browser") }}'
+        meta:
+          dimension:
+            type: string
 
       - name: utm_source
         data_type: string
         description: '{{ doc("col_utm_source") }}'
+        meta:
+          dimension:
+            type: string
 
       - name: utm_medium
         data_type: string
         description: '{{ doc("col_utm_medium") }}'
+        meta:
+          dimension:
+            type: string
 
       - name: utm_campaign
         data_type: string
         description: '{{ doc("col_utm_campaign") }}'
+        meta:
+          dimension:
+            type: string
 
       - name: session_duration_seconds
         data_type: int64
         description: '{{ doc("col_session_duration_seconds") }}'
+        meta:
+          dimension:
+            type: number
 
       - name: event_count
         data_type: int64
         description: '{{ doc("col_event_count") }}'
+        meta:
+          dimension:
+            type: number
 
       - name: page_view_count
         data_type: int64
         description: '{{ doc("col_page_view_count") }}'
+        meta:
+          dimension:
+            type: number
 
   - name: dim_experiments
     description: '{{ doc("dim_experiments") }}'
@@ -94,6 +130,9 @@ models:
       - name: experiment_key
         data_type: int64
         description: '{{ doc("col_experiment_key") }}'
+        meta:
+          dimension:
+            hidden: true
         data_tests:
           - unique
           - not_null
@@ -101,6 +140,9 @@ models:
       - name: experiment_id
         data_type: string
         description: '{{ doc("col_experiment_id") }}'
+        meta:
+          dimension:
+            hidden: true
         data_tests:
           - unique
           - not_null
@@ -108,12 +150,18 @@ models:
       - name: experiment_name
         data_type: string
         description: '{{ doc("col_experiment_name") }}'
+        meta:
+          dimension:
+            type: string
         data_tests:
           - not_null
 
       - name: status
         data_type: string
         description: '{{ doc("col_experiment_status") }}'
+        meta:
+          dimension:
+            type: string
         data_tests:
           - not_null
           - accepted_values:
@@ -126,16 +174,27 @@ models:
       - name: start_date
         data_type: date
         description: '{{ doc("col_experiment_start_date") }}'
+        meta:
+          dimension:
+            type: date
+            time_intervals: ["DAY", "WEEK", "MONTH", "QUARTER", "YEAR"]
         data_tests:
           - not_null
 
       - name: end_date
         data_type: date
         description: '{{ doc("col_experiment_end_date") }}'
+        meta:
+          dimension:
+            type: date
+            time_intervals: ["DAY", "WEEK", "MONTH", "QUARTER", "YEAR"]
 
       - name: description
         data_type: string
         description: '{{ doc("col_experiment_description") }}'
+        meta:
+          dimension:
+            type: string
 
   - name: bridge_user_experiments
     description: '{{ doc("bridge_user_experiments") }}'
@@ -153,6 +212,9 @@ models:
       - name: user_key
         data_type: int64
         description: '{{ doc("col_user_key") }}'
+        meta:
+          dimension:
+            hidden: true
         data_tests:
           - not_null
           - relationships:
@@ -167,12 +229,18 @@ models:
       - name: user_id
         data_type: string
         description: '{{ doc("col_user_id") }}'
+        meta:
+          dimension:
+            hidden: true
         data_tests:
           - not_null
 
       - name: experiment_key
         data_type: int64
         description: '{{ doc("col_experiment_key") }}'
+        meta:
+          dimension:
+            hidden: true
         data_tests:
           - not_null
           - relationships:
@@ -187,12 +255,19 @@ models:
       - name: variant
         data_type: string
         description: '{{ doc("col_variant") }}'
+        meta:
+          dimension:
+            type: string
         data_tests:
           - not_null
 
       - name: first_exposure_at
         data_type: timestamp
         description: '{{ doc("col_first_exposure_at") }}'
+        meta:
+          dimension:
+            type: timestamp
+            time_intervals: ["DAY", "WEEK", "MONTH", "QUARTER", "YEAR"]
         data_tests:
           - not_null
 
@@ -219,6 +294,13 @@ models:
       - name: feature_usage_key
         data_type: int64
         description: '{{ doc("col_feature_usage_key") }}'
+        meta:
+          dimension:
+            hidden: true
+          metric:
+            type: count_distinct
+            label: "Feature Usages"
+            description: 'Distinct feature-use events.'
         data_tests:
           - unique
           - not_null
@@ -226,6 +308,9 @@ models:
       - name: event_id
         data_type: string
         description: '{{ doc("col_event_id") }}'
+        meta:
+          dimension:
+            hidden: true
         data_tests:
           - unique
           - not_null
@@ -233,12 +318,18 @@ models:
       - name: user_id
         data_type: string
         description: '{{ doc("col_user_id") }}'
+        meta:
+          dimension:
+            hidden: true
         data_tests:
           - not_null
 
       - name: user_key
         data_type: int64
         description: '{{ doc("col_user_key") }}'
+        meta:
+          dimension:
+            hidden: true
         data_tests:
           - not_null
           - relationships:
@@ -253,10 +344,16 @@ models:
       - name: account_id
         data_type: string
         description: '{{ doc("col_account_id") }}'
+        meta:
+          dimension:
+            hidden: true
 
       - name: account_key
         data_type: int64
         description: '{{ doc("col_account_key") }}'
+        meta:
+          dimension:
+            hidden: true
         data_tests:
           - relationships:
               arguments:
@@ -271,6 +368,9 @@ models:
       - name: usage_date_key
         data_type: int64
         description: '{{ doc("col_usage_date_key") }}'
+        meta:
+          dimension:
+            hidden: true
         data_tests:
           - not_null
           - relationships:
@@ -285,12 +385,19 @@ models:
       - name: usage_at
         data_type: timestamp
         description: '{{ doc("col_usage_at") }}'
+        meta:
+          dimension:
+            type: timestamp
+            time_intervals: ["DAY", "WEEK", "MONTH", "QUARTER", "YEAR"]
         data_tests:
           - not_null
 
       - name: feature_name
         data_type: string
         description: '{{ doc("col_feature_name") }}'
+        meta:
+          dimension:
+            type: string
         data_tests:
           - not_null
           - accepted_values:
@@ -310,14 +417,23 @@ models:
       - name: feature_duration_seconds
         data_type: int64
         description: '{{ doc("col_feature_duration_seconds") }}'
+        meta:
+          dimension:
+            type: number
 
       - name: platform
         data_type: string
         description: '{{ doc("col_platform") }}'
+        meta:
+          dimension:
+            type: string
 
       - name: device_type
         data_type: string
         description: '{{ doc("col_device_type") }}'
+        meta:
+          dimension:
+            type: string
 
   - name: fct_sessions
     description: '{{ doc("fct_sessions") }}'
@@ -335,6 +451,13 @@ models:
       - name: session_key
         data_type: int64
         description: '{{ doc("col_session_key") }}'
+        meta:
+          dimension:
+            hidden: true
+          metric:
+            type: count_distinct
+            label: "Sessions"
+            description: 'Distinct session count.'
         data_tests:
           - unique
           - not_null
@@ -350,6 +473,9 @@ models:
       - name: session_id
         data_type: string
         description: '{{ doc("col_session_id") }}'
+        meta:
+          dimension:
+            hidden: true
         data_tests:
           - unique
           - not_null
@@ -357,10 +483,16 @@ models:
       - name: user_id
         data_type: string
         description: '{{ doc("col_user_id") }}'
+        meta:
+          dimension:
+            hidden: true
 
       - name: user_key
         data_type: int64
         description: '{{ doc("col_user_key") }}'
+        meta:
+          dimension:
+            hidden: true
         data_tests:
           - relationships:
               arguments:
@@ -375,6 +507,9 @@ models:
       - name: session_date_key
         data_type: int64
         description: '{{ doc("col_session_date_key") }}'
+        meta:
+          dimension:
+            hidden: true
         data_tests:
           - not_null
           - relationships:
@@ -389,54 +524,97 @@ models:
       - name: session_start_at
         data_type: timestamp
         description: '{{ doc("col_session_start_at") }}'
+        meta:
+          dimension:
+            type: timestamp
+            time_intervals: ["DAY", "WEEK", "MONTH", "QUARTER", "YEAR"]
         data_tests:
           - not_null
 
       - name: session_end_at
         data_type: timestamp
         description: '{{ doc("col_session_end_at") }}'
+        meta:
+          dimension:
+            type: timestamp
+            time_intervals: ["DAY", "WEEK", "MONTH", "QUARTER", "YEAR"]
         data_tests:
           - not_null
 
       - name: session_duration_seconds
         data_type: int64
         description: '{{ doc("col_session_duration_seconds") }}'
+        meta:
+          dimension:
+            type: number
+          metric:
+            type: average
+            label: "Avg Session Duration (s)"
+            description: 'Mean session length in seconds.'
         data_tests:
           - not_null
 
       - name: event_count
         data_type: int64
         description: '{{ doc("col_event_count") }}'
+        meta:
+          dimension:
+            type: number
+          metric:
+            type: sum
+            label: "Events"
+            description: 'Sum of events across sessions.'
         data_tests:
           - not_null
 
       - name: page_view_count
         data_type: int64
         description: '{{ doc("col_page_view_count") }}'
+        meta:
+          dimension:
+            type: number
 
       - name: platform
         data_type: string
         description: '{{ doc("col_platform") }}'
+        meta:
+          dimension:
+            type: string
 
       - name: device_type
         data_type: string
         description: '{{ doc("col_device_type") }}'
+        meta:
+          dimension:
+            type: string
 
       - name: browser
         data_type: string
         description: '{{ doc("col_browser") }}'
+        meta:
+          dimension:
+            type: string
 
       - name: utm_source
         data_type: string
         description: '{{ doc("col_utm_source") }}'
+        meta:
+          dimension:
+            type: string
 
       - name: utm_medium
         data_type: string
         description: '{{ doc("col_utm_medium") }}'
+        meta:
+          dimension:
+            type: string
 
       - name: utm_campaign
         data_type: string
         description: '{{ doc("col_utm_campaign") }}'
+        meta:
+          dimension:
+            type: string
 
   - name: fct_experiment_exposures
     description: '{{ doc("fct_experiment_exposures") }}'
@@ -454,12 +632,18 @@ models:
       - name: user_id
         data_type: string
         description: '{{ doc("col_user_id") }}'
+        meta:
+          dimension:
+            hidden: true
         data_tests:
           - not_null
 
       - name: user_key
         data_type: int64
         description: '{{ doc("col_user_key") }}'
+        meta:
+          dimension:
+            hidden: true
         data_tests:
           - not_null
           - relationships:
@@ -474,12 +658,18 @@ models:
       - name: experiment_id
         data_type: string
         description: '{{ doc("col_experiment_id") }}'
+        meta:
+          dimension:
+            hidden: true
         data_tests:
           - not_null
 
       - name: experiment_key
         data_type: int64
         description: '{{ doc("col_experiment_key") }}'
+        meta:
+          dimension:
+            hidden: true
         data_tests:
           - not_null
           - relationships:
@@ -494,6 +684,9 @@ models:
       - name: variant
         data_type: string
         description: '{{ doc("col_variant") }}'
+        meta:
+          dimension:
+            type: string
         data_tests:
           - not_null
           - accepted_values:
@@ -505,12 +698,19 @@ models:
       - name: first_exposure_at
         data_type: timestamp
         description: '{{ doc("col_first_exposure_at") }}'
+        meta:
+          dimension:
+            type: timestamp
+            time_intervals: ["DAY", "WEEK", "MONTH", "QUARTER", "YEAR"]
         data_tests:
           - not_null
 
       - name: exposure_date_key
         data_type: int64
         description: '{{ doc("col_exposure_date_key") }}'
+        meta:
+          dimension:
+            hidden: true
         data_tests:
           - not_null
           - relationships:
@@ -525,16 +725,26 @@ models:
       - name: converted
         data_type: boolean
         description: '{{ doc("col_converted") }}'
+        meta:
+          dimension:
+            type: boolean
         data_tests:
           - not_null
 
       - name: conversion_at
         data_type: timestamp
         description: '{{ doc("col_conversion_at") }}'
+        meta:
+          dimension:
+            type: timestamp
+            time_intervals: ["DAY", "WEEK", "MONTH", "QUARTER", "YEAR"]
 
       - name: exposure_duration_hours
         data_type: int64
         description: '{{ doc("col_exposure_duration_hours") }}'
+        meta:
+          dimension:
+            type: number
         data_tests:
           - not_null
 

--- a/models/marts/support/_models.yml
+++ b/models/marts/support/_models.yml
@@ -17,6 +17,13 @@ models:
       - name: ticket_key
         data_type: int64
         description: '{{ doc("col_ticket_key") }}'
+        meta:
+          dimension:
+            hidden: true
+          metric:
+            type: count_distinct
+            label: "Tickets"
+            description: 'Distinct support tickets.'
         data_tests:
           - unique
           - not_null
@@ -24,6 +31,9 @@ models:
       - name: ticket_id
         data_type: string
         description: '{{ doc("col_ticket_id") }}'
+        meta:
+          dimension:
+            hidden: true
         data_tests:
           - unique
           - not_null
@@ -31,12 +41,18 @@ models:
       - name: user_id
         data_type: string
         description: '{{ doc("col_user_id") }}'
+        meta:
+          dimension:
+            hidden: true
         data_tests:
           - not_null
 
       - name: user_key
         data_type: int64
         description: '{{ doc("col_user_key") }}'
+        meta:
+          dimension:
+            hidden: true
         data_tests:
           - not_null
           - relationships:
@@ -51,12 +67,18 @@ models:
       - name: account_id
         data_type: string
         description: '{{ doc("col_account_id") }}'
+        meta:
+          dimension:
+            hidden: true
         data_tests:
           - not_null
 
       - name: account_key
         data_type: int64
         description: '{{ doc("col_account_key") }}'
+        meta:
+          dimension:
+            hidden: true
         data_tests:
           - not_null
           - relationships:
@@ -71,6 +93,9 @@ models:
       - name: created_date_key
         data_type: int64
         description: '{{ doc("col_created_date_key") }}'
+        meta:
+          dimension:
+            hidden: true
         data_tests:
           - not_null
           - relationships:
@@ -85,16 +110,27 @@ models:
       - name: created_at
         data_type: timestamp
         description: '{{ doc("col_created_at") }}'
+        meta:
+          dimension:
+            type: timestamp
+            time_intervals: ["DAY", "WEEK", "MONTH", "QUARTER", "YEAR"]
         data_tests:
           - not_null
 
       - name: resolved_at
         data_type: timestamp
         description: '{{ doc("col_resolved_at") }}'
+        meta:
+          dimension:
+            type: timestamp
+            time_intervals: ["DAY", "WEEK", "MONTH", "QUARTER", "YEAR"]
 
       - name: category
         data_type: string
         description: '{{ doc("col_category") }}'
+        meta:
+          dimension:
+            type: string
         data_tests:
           - not_null
           - accepted_values:
@@ -109,6 +145,9 @@ models:
       - name: priority
         data_type: string
         description: '{{ doc("col_priority") }}'
+        meta:
+          dimension:
+            type: string
         data_tests:
           - not_null
           - accepted_values:
@@ -122,6 +161,9 @@ models:
       - name: status
         data_type: string
         description: '{{ doc("col_ticket_status") }}'
+        meta:
+          dimension:
+            type: string
         data_tests:
           - not_null
           - accepted_values:
@@ -135,17 +177,37 @@ models:
       - name: csat_score
         data_type: int64
         description: '{{ doc("col_csat_score") }}'
+        meta:
+          dimension:
+            type: number
+          metric:
+            type: average
+            label: "Avg CSAT"
+            description: 'Mean customer-satisfaction score (1–5). Null responses excluded.'
 
       - name: resolution_time_hours
         data_type: float64
         description: '{{ doc("col_resolution_time_hours") }}'
+        meta:
+          dimension:
+            type: number
+          metric:
+            type: average
+            label: "Avg Resolution Time (h)"
+            description: 'Mean ticket resolution time in hours. Includes only resolved tickets.'
 
       - name: first_response_hours
         data_type: float64
         description: '{{ doc("col_first_response_hours") }}'
+        meta:
+          dimension:
+            type: number
 
       - name: is_resolved
         data_type: boolean
         description: '{{ doc("col_is_resolved") }}'
+        meta:
+          dimension:
+            type: boolean
         data_tests:
           - not_null

--- a/scripts/lint-doc-blocks.sh
+++ b/scripts/lint-doc-blocks.sh
@@ -49,10 +49,14 @@ check_inline_descriptions() {
                 echo "      $line_content"
                 WARN_COUNT=$((WARN_COUNT + 1))
             fi
-        done < <(grep -nE '^\s+description:\s' "$file" \
+        # Only flag description: lines at model-level (4-space indent) or column-level
+        # (8-space indent). Deeper indents (12+ spaces) sit inside nested config blocks
+        # like `meta.metric.description` and are allowed — those are Lightdash metric
+        # descriptions, not column docs.
+        done < <(grep -nE '^( {4}|        )description:\s' "$file" \
             | grep -vE '\{\{.*doc\(' \
-            | grep -vE '^\s+description:\s*$' \
-            | grep -vE "^\s+description:\s*['\"]?\s*['\"]?\s*$" \
+            | grep -vE 'description:\s*$' \
+            | grep -vE "description:\s*['\"]?\s*['\"]?\s*$" \
             || true)
     done < <(find "$search_dir" -name "$pattern" -print0 2>/dev/null)
 }


### PR DESCRIPTION
## Summary

Adds the dbt-side half of agentic-hub#393. Lightdash will pick these up from the dbt manifest and surface curated dimensions + metrics in its explorer. The Lightdash-side join YAML lands in a paired PR on the sibling repo.

## Dimensions (198 columns)

Applied programmatically by column-name + data_type rules. Same pattern across all 17 mart models:

| Pattern | data_type | Annotation |
|---|---|---|
| \`*_key\` | int64 | \`hidden: true\` (joinable, not visible in UI) |
| \`*_id\` | string | \`hidden: true\` |
| \`*_date\` | date | \`type: date\`, intervals DAY → YEAR |
| \`*_at\` / \`*_time\` | timestamp | \`type: timestamp\`, same intervals |
| \`is_*\` / \`has_*\` / \`was_*\` | boolean | \`type: boolean\` |
| other string | — | \`type: string\` |
| other numeric | — | \`type: number\` |

## Metrics (23 columns across 11 marts)

| Model | Column | Type | Label |
|---|---|---|---|
| \`fct_signups\` | \`signup_key\` | count_distinct | Signups |
| \`fct_activations\` | \`activation_key\` | count_distinct | Activations |
| \`fct_subscriptions\` | \`mrr_amount\` | sum | Subscription MRR |
| \`fct_mrr_movements\` | \`mrr_delta\` | sum | Net MRR |
| \`fct_invoices\` | \`invoice_key\` / \`amount\` / \`net_amount\` | count_distinct / sum / sum | Invoices / Invoice Amount / Net Revenue |
| \`dim_accounts\` | \`mrr_amount\` / \`health_score\` / \`user_count\` | sum / average / sum | Total MRR / Avg Health / Total Users |
| \`fct_retention_cohorts\` | \`cohort_size\` / \`retained_count\` / \`retention_rate\` | sum / sum / average | (matching labels) |
| \`fct_marketing_spend\` | \`spend_amount\` / \`impressions\` / \`clicks\` | sum / sum / sum | Marketing Spend / Impressions / Clicks |
| \`fct_sessions\` | \`session_key\` / \`session_duration_seconds\` / \`event_count\` | count_distinct / average / sum | Sessions / Avg Session Duration / Events |
| \`fct_feature_usage\` | \`feature_usage_key\` | count_distinct | Feature Usages |
| \`fct_support_tickets\` | \`ticket_key\` / \`csat_score\` / \`resolution_time_hours\` | count_distinct / average / average | Tickets / Avg CSAT / Avg Resolution Time |

Each metric reflects the canonical definitions from \`docs/metric-contract.md\` — no new business semantics introduced; Lightdash surfaces what dbt already defines.

## What's unchanged

- Existing model-level \`meta\` (owner, pii, sla, tier) — untouched
- Column descriptions, doc tags — untouched
- Test configuration — untouched
- All YAML still parses cleanly

## Validation

- All 5 mart \`_models.yml\` files parse as valid YAML
- Annotation script is idempotent (re-running adds nothing)
- decisions.md entry added documenting the policy and trade-offs

## Closes

Dbt-side of agentic-hub#393. The Lightdash-side join YAML lands as a paired PR on \`b2b-saas-lightdash\` once this merges.