### PR TITLE
fix: align Lightdash metric annotations with official convention

### DIFF
--- a/models/marts/billing/_models.yml
+++ b/models/marts/billing/_models.yml
@@ -195,10 +195,11 @@ models:
         meta:
           dimension:
             type: number
-          metric:
-            type: sum
-            label: "Subscription MRR"
-            description: 'Sum of MRR amounts at subscription event time.'
+          metrics:
+            subscription_mrr:
+              type: sum
+              label: "Subscription MRR"
+              description: 'Sum of MRR amounts at subscription event time.'
         data_tests:
           - not_null
 
@@ -381,10 +382,11 @@ models:
         meta:
           dimension:
             type: number
-          metric:
-            type: sum
-            label: "Net MRR"
-            description: 'Cumulative sum of MRR movements. Decomposes into new / expansion / contraction / churn / reactivation via the movement_type dimension.'
+          metrics:
+            net_mrr:
+              type: sum
+              label: "Net MRR"
+              description: 'Cumulative sum of MRR movements. Decomposes into new / expansion / contraction / churn / reactivation via the movement_type dimension.'
         data_tests:
           - not_null
 
@@ -414,10 +416,11 @@ models:
         meta:
           dimension:
             hidden: true
-          metric:
-            type: count_distinct
-            label: "Invoices"
-            description: 'Distinct invoices issued.'
+          metrics:
+            invoices:
+              type: count_distinct
+              label: "Invoices"
+              description: 'Distinct invoices issued.'
         data_tests:
           - unique
           - not_null
@@ -534,10 +537,11 @@ models:
         meta:
           dimension:
             type: number
-          metric:
-            type: sum
-            label: "Invoice Amount"
-            description: 'Sum of invoice amounts billed.'
+          metrics:
+            invoice_amount:
+              type: sum
+              label: "Invoice Amount"
+              description: 'Sum of invoice amounts billed.'
         data_tests:
           - not_null
 
@@ -586,10 +590,11 @@ models:
         meta:
           dimension:
             type: number
-          metric:
-            type: sum
-            label: "Net Revenue"
-            description: 'Sum of net amounts (amount minus refunds). Excludes refunded invoices.'
+          metrics:
+            net_revenue:
+              type: sum
+              label: "Net Revenue"
+              description: 'Sum of net amounts (amount minus refunds). Excludes refunded invoices.'
         data_tests:
           - not_null
 

--- a/models/marts/billing/_models.yml
+++ b/models/marts/billing/_models.yml
@@ -17,9 +17,10 @@ models:
       - name: subscription_event_key
         data_type: int64
         description: '{{ doc("col_subscription_event_key") }}'
-        meta:
-          dimension:
-            hidden: true
+        config:
+          meta:
+            dimension:
+              hidden: true
         data_tests:
           - unique
           - not_null
@@ -27,9 +28,10 @@ models:
       - name: subscription_event_id
         data_type: string
         description: '{{ doc("col_subscription_event_id") }}'
-        meta:
-          dimension:
-            hidden: true
+        config:
+          meta:
+            dimension:
+              hidden: true
         data_tests:
           - unique
           - not_null
@@ -37,27 +39,30 @@ models:
       - name: subscription_id
         data_type: string
         description: '{{ doc("col_subscription_id") }}'
-        meta:
-          dimension:
-            hidden: true
+        config:
+          meta:
+            dimension:
+              hidden: true
         data_tests:
           - not_null
 
       - name: user_id
         data_type: string
         description: '{{ doc("col_user_id") }}'
-        meta:
-          dimension:
-            hidden: true
+        config:
+          meta:
+            dimension:
+              hidden: true
         data_tests:
           - not_null
 
       - name: user_key
         data_type: int64
         description: '{{ doc("col_user_key") }}'
-        meta:
-          dimension:
-            hidden: true
+        config:
+          meta:
+            dimension:
+              hidden: true
         data_tests:
           - not_null
           - relationships:
@@ -72,18 +77,20 @@ models:
       - name: account_id
         data_type: string
         description: '{{ doc("col_account_id") }}'
-        meta:
-          dimension:
-            hidden: true
+        config:
+          meta:
+            dimension:
+              hidden: true
         data_tests:
           - not_null
 
       - name: account_key
         data_type: int64
         description: '{{ doc("col_account_key") }}'
-        meta:
-          dimension:
-            hidden: true
+        config:
+          meta:
+            dimension:
+              hidden: true
         data_tests:
           - not_null
           - relationships:
@@ -98,9 +105,10 @@ models:
       - name: event_date_key
         data_type: int64
         description: '{{ doc("col_event_date_key") }}'
-        meta:
-          dimension:
-            hidden: true
+        config:
+          meta:
+            dimension:
+              hidden: true
         data_tests:
           - not_null
           - relationships:
@@ -115,19 +123,21 @@ models:
       - name: event_time
         data_type: timestamp
         description: '{{ doc("col_event_time") }}'
-        meta:
-          dimension:
-            type: timestamp
-            time_intervals: ["DAY", "WEEK", "MONTH", "QUARTER", "YEAR"]
+        config:
+          meta:
+            dimension:
+              type: timestamp
+              time_intervals: ["DAY", "WEEK", "MONTH", "QUARTER", "YEAR"]
         data_tests:
           - not_null
 
       - name: event_type
         data_type: string
         description: '{{ doc("col_event_type") }}'
-        meta:
-          dimension:
-            type: string
+        config:
+          meta:
+            dimension:
+              type: string
         data_tests:
           - not_null
           - accepted_values:
@@ -145,9 +155,10 @@ models:
       - name: plan
         data_type: string
         description: '{{ doc("col_plan") }}'
-        meta:
-          dimension:
-            type: string
+        config:
+          meta:
+            dimension:
+              type: string
         data_tests:
           - not_null
           - accepted_values:
@@ -161,9 +172,10 @@ models:
       - name: previous_plan
         data_type: string
         description: '{{ doc("col_previous_plan") }}'
-        meta:
-          dimension:
-            type: string
+        config:
+          meta:
+            dimension:
+              type: string
         data_tests:
           - accepted_values:
               arguments:
@@ -178,9 +190,10 @@ models:
       - name: billing_cycle
         data_type: string
         description: '{{ doc("col_billing_cycle") }}'
-        meta:
-          dimension:
-            type: string
+        config:
+          meta:
+            dimension:
+              type: string
         data_tests:
           - not_null
           - accepted_values:
@@ -192,23 +205,25 @@ models:
       - name: mrr_amount
         data_type: numeric
         description: '{{ doc("col_mrr_amount") }}'
-        meta:
-          dimension:
-            type: number
-          metrics:
-            subscription_mrr:
-              type: sum
-              label: "Subscription MRR"
-              description: 'Sum of MRR amounts at subscription event time.'
+        config:
+          meta:
+            dimension:
+              type: number
+            metrics:
+              subscription_mrr:
+                type: sum
+                label: "Subscription MRR"
+                description: 'Sum of MRR amounts at subscription event time.'
         data_tests:
           - not_null
 
       - name: currency
         data_type: string
         description: '{{ doc("col_currency") }}'
-        meta:
-          dimension:
-            type: string
+        config:
+          meta:
+            dimension:
+              type: string
         data_tests:
           - not_null
           - accepted_values:
@@ -220,32 +235,36 @@ models:
       - name: cancel_reason
         data_type: string
         description: '{{ doc("col_cancel_reason") }}'
-        meta:
-          dimension:
-            type: string
+        config:
+          meta:
+            dimension:
+              type: string
 
       - name: is_voluntary
         data_type: boolean
         description: '{{ doc("col_is_voluntary") }}'
-        meta:
-          dimension:
-            type: boolean
+        config:
+          meta:
+            dimension:
+              type: boolean
 
       - name: is_active
         data_type: boolean
         description: '{{ doc("col_is_active") }}'
-        meta:
-          dimension:
-            type: boolean
+        config:
+          meta:
+            dimension:
+              type: boolean
         data_tests:
           - not_null
 
       - name: days_since_previous_event
         data_type: int64
         description: '{{ doc("col_days_since_previous_event") }}'
-        meta:
-          dimension:
-            type: number
+        config:
+          meta:
+            dimension:
+              type: number
 
   - name: fct_mrr_movements
     description: '{{ doc("fct_mrr_movements") }}'
@@ -263,9 +282,10 @@ models:
       - name: mrr_movement_key
         data_type: int64
         description: '{{ doc("col_mrr_movement_key") }}'
-        meta:
-          dimension:
-            hidden: true
+        config:
+          meta:
+            dimension:
+              hidden: true
         data_tests:
           - unique
           - not_null
@@ -273,18 +293,20 @@ models:
       - name: account_id
         data_type: string
         description: '{{ doc("col_account_id") }}'
-        meta:
-          dimension:
-            hidden: true
+        config:
+          meta:
+            dimension:
+              hidden: true
         data_tests:
           - not_null
 
       - name: account_key
         data_type: int64
         description: '{{ doc("col_account_key") }}'
-        meta:
-          dimension:
-            hidden: true
+        config:
+          meta:
+            dimension:
+              hidden: true
         data_tests:
           - not_null
           - relationships:
@@ -299,27 +321,30 @@ models:
       - name: subscription_event_id
         data_type: string
         description: '{{ doc("col_subscription_event_id") }}'
-        meta:
-          dimension:
-            hidden: true
+        config:
+          meta:
+            dimension:
+              hidden: true
         data_tests:
           - not_null
 
       - name: subscription_id
         data_type: string
         description: '{{ doc("col_subscription_id") }}'
-        meta:
-          dimension:
-            hidden: true
+        config:
+          meta:
+            dimension:
+              hidden: true
         data_tests:
           - not_null
 
       - name: movement_date_key
         data_type: int64
         description: '{{ doc("col_movement_date_key") }}'
-        meta:
-          dimension:
-            hidden: true
+        config:
+          meta:
+            dimension:
+              hidden: true
         data_tests:
           - not_null
           - relationships:
@@ -334,19 +359,21 @@ models:
       - name: movement_date
         data_type: date
         description: '{{ doc("col_movement_date") }}'
-        meta:
-          dimension:
-            type: date
-            time_intervals: ["DAY", "WEEK", "MONTH", "QUARTER", "YEAR"]
+        config:
+          meta:
+            dimension:
+              type: date
+              time_intervals: ["DAY", "WEEK", "MONTH", "QUARTER", "YEAR"]
         data_tests:
           - not_null
 
       - name: movement_type
         data_type: string
         description: '{{ doc("col_movement_type") }}'
-        meta:
-          dimension:
-            type: string
+        config:
+          meta:
+            dimension:
+              type: string
         data_tests:
           - not_null
           - accepted_values:
@@ -361,32 +388,35 @@ models:
       - name: mrr_before
         data_type: numeric
         description: '{{ doc("col_mrr_before") }}'
-        meta:
-          dimension:
-            type: number
+        config:
+          meta:
+            dimension:
+              type: number
         data_tests:
           - not_null
 
       - name: mrr_after
         data_type: numeric
         description: '{{ doc("col_mrr_after") }}'
-        meta:
-          dimension:
-            type: number
+        config:
+          meta:
+            dimension:
+              type: number
         data_tests:
           - not_null
 
       - name: mrr_delta
         data_type: numeric
         description: '{{ doc("col_mrr_delta") }}'
-        meta:
-          dimension:
-            type: number
-          metrics:
-            net_mrr:
-              type: sum
-              label: "Net MRR"
-              description: 'Cumulative sum of MRR movements. Decomposes into new / expansion / contraction / churn / reactivation via the movement_type dimension.'
+        config:
+          meta:
+            dimension:
+              type: number
+            metrics:
+              net_mrr:
+                type: sum
+                label: "Net MRR"
+                description: 'Cumulative sum of MRR movements. Decomposes into new / expansion / contraction / churn / reactivation via the movement_type dimension.'
         data_tests:
           - not_null
 
@@ -413,14 +443,15 @@ models:
       - name: invoice_key
         data_type: int64
         description: '{{ doc("col_invoice_key") }}'
-        meta:
-          dimension:
-            hidden: true
-          metrics:
-            invoices:
-              type: count_distinct
-              label: "Invoices"
-              description: 'Distinct invoices issued.'
+        config:
+          meta:
+            dimension:
+              hidden: true
+            metrics:
+              invoices:
+                type: count_distinct
+                label: "Invoices"
+                description: 'Distinct invoices issued.'
         data_tests:
           - unique
           - not_null
@@ -428,9 +459,10 @@ models:
       - name: invoice_id
         data_type: string
         description: '{{ doc("col_invoice_id") }}'
-        meta:
-          dimension:
-            hidden: true
+        config:
+          meta:
+            dimension:
+              hidden: true
         data_tests:
           - unique
           - not_null
@@ -438,27 +470,30 @@ models:
       - name: subscription_id
         data_type: string
         description: '{{ doc("col_subscription_id") }}'
-        meta:
-          dimension:
-            hidden: true
+        config:
+          meta:
+            dimension:
+              hidden: true
         data_tests:
           - not_null
 
       - name: user_id
         data_type: string
         description: '{{ doc("col_user_id") }}'
-        meta:
-          dimension:
-            hidden: true
+        config:
+          meta:
+            dimension:
+              hidden: true
         data_tests:
           - not_null
 
       - name: user_key
         data_type: int64
         description: '{{ doc("col_user_key") }}'
-        meta:
-          dimension:
-            hidden: true
+        config:
+          meta:
+            dimension:
+              hidden: true
         data_tests:
           - not_null
           - relationships:
@@ -473,18 +508,20 @@ models:
       - name: account_id
         data_type: string
         description: '{{ doc("col_account_id") }}'
-        meta:
-          dimension:
-            hidden: true
+        config:
+          meta:
+            dimension:
+              hidden: true
         data_tests:
           - not_null
 
       - name: account_key
         data_type: int64
         description: '{{ doc("col_account_key") }}'
-        meta:
-          dimension:
-            hidden: true
+        config:
+          meta:
+            dimension:
+              hidden: true
         data_tests:
           - not_null
           - relationships:
@@ -499,9 +536,10 @@ models:
       - name: issued_date_key
         data_type: int64
         description: '{{ doc("col_issued_date_key") }}'
-        meta:
-          dimension:
-            hidden: true
+        config:
+          meta:
+            dimension:
+              hidden: true
         data_tests:
           - not_null
           - relationships:
@@ -516,41 +554,45 @@ models:
       - name: issued_at
         data_type: timestamp
         description: '{{ doc("col_issued_at") }}'
-        meta:
-          dimension:
-            type: timestamp
-            time_intervals: ["DAY", "WEEK", "MONTH", "QUARTER", "YEAR"]
+        config:
+          meta:
+            dimension:
+              type: timestamp
+              time_intervals: ["DAY", "WEEK", "MONTH", "QUARTER", "YEAR"]
         data_tests:
           - not_null
 
       - name: paid_at
         data_type: timestamp
         description: '{{ doc("col_paid_at") }}'
-        meta:
-          dimension:
-            type: timestamp
-            time_intervals: ["DAY", "WEEK", "MONTH", "QUARTER", "YEAR"]
+        config:
+          meta:
+            dimension:
+              type: timestamp
+              time_intervals: ["DAY", "WEEK", "MONTH", "QUARTER", "YEAR"]
 
       - name: amount
         data_type: numeric
         description: '{{ doc("col_amount") }}'
-        meta:
-          dimension:
-            type: number
-          metrics:
-            invoice_amount:
-              type: sum
-              label: "Invoice Amount"
-              description: 'Sum of invoice amounts billed.'
+        config:
+          meta:
+            dimension:
+              type: number
+            metrics:
+              invoice_amount:
+                type: sum
+                label: "Invoice Amount"
+                description: 'Sum of invoice amounts billed.'
         data_tests:
           - not_null
 
       - name: currency
         data_type: string
         description: '{{ doc("col_currency") }}'
-        meta:
-          dimension:
-            type: string
+        config:
+          meta:
+            dimension:
+              type: string
         data_tests:
           - not_null
           - accepted_values:
@@ -562,9 +604,10 @@ models:
       - name: status
         data_type: string
         description: '{{ doc("col_invoice_status") }}'
-        meta:
-          dimension:
-            type: string
+        config:
+          meta:
+            dimension:
+              type: string
         data_tests:
           - not_null
           - accepted_values:
@@ -578,31 +621,34 @@ models:
       - name: refund_amount
         data_type: numeric
         description: '{{ doc("col_refund_amount") }}'
-        meta:
-          dimension:
-            type: number
+        config:
+          meta:
+            dimension:
+              type: number
         data_tests:
           - not_null
 
       - name: net_amount
         data_type: numeric
         description: '{{ doc("col_net_amount") }}'
-        meta:
-          dimension:
-            type: number
-          metrics:
-            net_revenue:
-              type: sum
-              label: "Net Revenue"
-              description: 'Sum of net amounts (amount minus refunds). Excludes refunded invoices.'
+        config:
+          meta:
+            dimension:
+              type: number
+            metrics:
+              net_revenue:
+                type: sum
+                label: "Net Revenue"
+                description: 'Sum of net amounts (amount minus refunds). Excludes refunded invoices.'
         data_tests:
           - not_null
 
       - name: is_paid
         data_type: boolean
         description: '{{ doc("col_is_paid") }}'
-        meta:
-          dimension:
-            type: boolean
+        config:
+          meta:
+            dimension:
+              type: boolean
         data_tests:
           - not_null

--- a/models/marts/core/_models.yml
+++ b/models/marts/core/_models.yml
@@ -229,10 +229,11 @@ models:
         meta:
           dimension:
             type: number
-          metric:
-            type: sum
-            label: "Total MRR"
-            description: 'Sum of MRR across all accounts.'
+          metrics:
+            total_mrr:
+              type: sum
+              label: "Total MRR"
+              description: 'Sum of MRR across all accounts.'
 
       - name: currency
         data_type: string
@@ -247,10 +248,11 @@ models:
         meta:
           dimension:
             type: number
-          metric:
-            type: sum
-            label: "Total Users"
-            description: 'Sum of users across accounts.'
+          metrics:
+            total_users:
+              type: sum
+              label: "Total Users"
+              description: 'Sum of users across accounts.'
 
       - name: health_score
         data_type: float64
@@ -258,10 +260,11 @@ models:
         meta:
           dimension:
             type: number
-          metric:
-            type: average
-            label: "Avg Health Score"
-            description: 'Mean account health score (0–100).'
+          metrics:
+            avg_health_score:
+              type: average
+              label: "Avg Health Score"
+              description: 'Mean account health score (0–100).'
 
       - name: activity_score
         data_type: float64
@@ -344,10 +347,11 @@ models:
         meta:
           dimension:
             hidden: true
-          metric:
-            type: count_distinct
-            label: "Signups"
-            description: 'Distinct signup events.'
+          metrics:
+            signups:
+              type: count_distinct
+              label: "Signups"
+              description: 'Distinct signup events.'
         data_tests:
           - unique
           - not_null
@@ -517,10 +521,11 @@ models:
         meta:
           dimension:
             hidden: true
-          metric:
-            type: count_distinct
-            label: "Activations"
-            description: 'Distinct activation events — users who completed an activation action within the window.'
+          metrics:
+            activations:
+              type: count_distinct
+              label: "Activations"
+              description: 'Distinct activation events — users who completed an activation action within the window.'
         data_tests:
           - unique
           - not_null
@@ -748,10 +753,11 @@ models:
         meta:
           dimension:
             type: number
-          metric:
-            type: sum
-            label: "Cohort Size"
-            description: 'Sum of users in each cohort window.'
+          metrics:
+            cohort_size:
+              type: sum
+              label: "Cohort Size"
+              description: 'Sum of users in each cohort window.'
         data_tests:
           - not_null
 
@@ -761,10 +767,11 @@ models:
         meta:
           dimension:
             type: number
-          metric:
-            type: sum
-            label: "Retained Users"
-            description: 'Sum of users retained at each period.'
+          metrics:
+            retained_count:
+              type: sum
+              label: "Retained Users"
+              description: 'Sum of users retained at each period.'
         data_tests:
           - not_null
 
@@ -774,10 +781,11 @@ models:
         meta:
           dimension:
             type: number
-          metric:
-            type: average
-            label: "Retention Rate"
-            description: 'Mean retention rate across cohorts. Note: cohort_size-weighted mean is preferred for executive reporting.'
+          metrics:
+            retention_rate:
+              type: average
+              label: "Retention Rate"
+              description: 'Mean retention rate across cohorts. Note: cohort_size-weighted mean is preferred for executive reporting.'
         data_tests:
           - not_null
 

--- a/models/marts/core/_models.yml
+++ b/models/marts/core/_models.yml
@@ -17,9 +17,10 @@ models:
       - name: channel_key
         data_type: int64
         description: '{{ doc("col_channel_key") }}'
-        meta:
-          dimension:
-            hidden: true
+        config:
+          meta:
+            dimension:
+              hidden: true
         data_tests:
           - unique
           - not_null
@@ -27,9 +28,10 @@ models:
       - name: channel
         data_type: string
         description: '{{ doc("col_channel") }}'
-        meta:
-          dimension:
-            type: string
+        config:
+          meta:
+            dimension:
+              type: string
         data_tests:
           - unique
           - not_null
@@ -50,9 +52,10 @@ models:
       - name: user_key
         data_type: int64
         description: '{{ doc("col_user_key") }}'
-        meta:
-          dimension:
-            hidden: true
+        config:
+          meta:
+            dimension:
+              hidden: true
         data_tests:
           - unique
           - not_null
@@ -60,9 +63,10 @@ models:
       - name: user_id
         data_type: string
         description: '{{ doc("col_user_id") }}'
-        meta:
-          dimension:
-            hidden: true
+        config:
+          meta:
+            dimension:
+              hidden: true
         data_tests:
           - unique
           - not_null
@@ -70,32 +74,36 @@ models:
       - name: account_id
         data_type: string
         description: '{{ doc("col_account_id") }}'
-        meta:
-          dimension:
-            hidden: true
+        config:
+          meta:
+            dimension:
+              hidden: true
 
       - name: signup_at
         data_type: timestamp
         description: '{{ doc("col_signup_at") }}'
-        meta:
-          dimension:
-            type: timestamp
-            time_intervals: ["DAY", "WEEK", "MONTH", "QUARTER", "YEAR"]
+        config:
+          meta:
+            dimension:
+              type: timestamp
+              time_intervals: ["DAY", "WEEK", "MONTH", "QUARTER", "YEAR"]
 
       - name: activation_at
         data_type: timestamp
         description: '{{ doc("col_activation_at") }}'
-        meta:
-          dimension:
-            type: timestamp
-            time_intervals: ["DAY", "WEEK", "MONTH", "QUARTER", "YEAR"]
+        config:
+          meta:
+            dimension:
+              type: timestamp
+              time_intervals: ["DAY", "WEEK", "MONTH", "QUARTER", "YEAR"]
 
       - name: first_touch_channel_key
         data_type: int64
         description: '{{ doc("col_first_touch_channel_key") }}'
-        meta:
-          dimension:
-            hidden: true
+        config:
+          meta:
+            dimension:
+              hidden: true
         data_tests:
           - relationships:
               arguments:
@@ -110,9 +118,10 @@ models:
       - name: last_touch_channel_key
         data_type: int64
         description: '{{ doc("col_last_touch_channel_key") }}'
-        meta:
-          dimension:
-            hidden: true
+        config:
+          meta:
+            dimension:
+              hidden: true
         data_tests:
           - relationships:
               arguments:
@@ -127,9 +136,10 @@ models:
       - name: engagement_state
         data_type: string
         description: '{{ doc("col_engagement_state") }}'
-        meta:
-          dimension:
-            type: string
+        config:
+          meta:
+            dimension:
+              type: string
         data_tests:
           - not_null
           - accepted_values:
@@ -143,36 +153,40 @@ models:
       - name: is_re_engaged
         data_type: boolean
         description: '{{ doc("col_is_re_engaged") }}'
-        meta:
-          dimension:
-            type: boolean
+        config:
+          meta:
+            dimension:
+              type: boolean
         data_tests:
           - not_null
 
       - name: is_product_user
         data_type: boolean
         description: '{{ doc("col_is_product_user") }}'
-        meta:
-          dimension:
-            type: boolean
+        config:
+          meta:
+            dimension:
+              type: boolean
         data_tests:
           - not_null
 
       - name: is_billing_user
         data_type: boolean
         description: '{{ doc("col_is_billing_user") }}'
-        meta:
-          dimension:
-            type: boolean
+        config:
+          meta:
+            dimension:
+              type: boolean
         data_tests:
           - not_null
 
       - name: is_support_user
         data_type: boolean
         description: '{{ doc("col_is_support_user") }}'
-        meta:
-          dimension:
-            type: boolean
+        config:
+          meta:
+            dimension:
+              type: boolean
         data_tests:
           - not_null
 
@@ -192,9 +206,10 @@ models:
       - name: account_key
         data_type: int64
         description: '{{ doc("col_account_key") }}'
-        meta:
-          dimension:
-            hidden: true
+        config:
+          meta:
+            dimension:
+              hidden: true
         data_tests:
           - unique
           - not_null
@@ -202,9 +217,10 @@ models:
       - name: account_id
         data_type: string
         description: '{{ doc("col_account_id") }}'
-        meta:
-          dimension:
-            hidden: true
+        config:
+          meta:
+            dimension:
+              hidden: true
         data_tests:
           - unique
           - not_null
@@ -212,87 +228,97 @@ models:
       - name: plan
         data_type: string
         description: '{{ doc("col_plan") }}'
-        meta:
-          dimension:
-            type: string
+        config:
+          meta:
+            dimension:
+              type: string
 
       - name: billing_cycle
         data_type: string
         description: '{{ doc("col_billing_cycle") }}'
-        meta:
-          dimension:
-            type: string
+        config:
+          meta:
+            dimension:
+              type: string
 
       - name: mrr_amount
         data_type: numeric
         description: '{{ doc("col_mrr_amount") }}'
-        meta:
-          dimension:
-            type: number
-          metrics:
-            total_mrr:
-              type: sum
-              label: "Total MRR"
-              description: 'Sum of MRR across all accounts.'
+        config:
+          meta:
+            dimension:
+              type: number
+            metrics:
+              total_mrr:
+                type: sum
+                label: "Total MRR"
+                description: 'Sum of MRR across all accounts.'
 
       - name: currency
         data_type: string
         description: '{{ doc("col_currency") }}'
-        meta:
-          dimension:
-            type: string
+        config:
+          meta:
+            dimension:
+              type: string
 
       - name: user_count
         data_type: int64
         description: '{{ doc("col_user_count") }}'
-        meta:
-          dimension:
-            type: number
-          metrics:
-            total_users:
-              type: sum
-              label: "Total Users"
-              description: 'Sum of users across accounts.'
+        config:
+          meta:
+            dimension:
+              type: number
+            metrics:
+              total_users:
+                type: sum
+                label: "Total Users"
+                description: 'Sum of users across accounts.'
 
       - name: health_score
         data_type: float64
         description: '{{ doc("col_health_score") }}'
-        meta:
-          dimension:
-            type: number
-          metrics:
-            avg_health_score:
-              type: average
-              label: "Avg Health Score"
-              description: 'Mean account health score (0–100).'
+        config:
+          meta:
+            dimension:
+              type: number
+            metrics:
+              avg_health_score:
+                type: average
+                label: "Avg Health Score"
+                description: 'Mean account health score (0–100).'
 
       - name: activity_score
         data_type: float64
         description: '{{ doc("col_activity_score") }}'
-        meta:
-          dimension:
-            type: number
+        config:
+          meta:
+            dimension:
+              type: number
 
       - name: billing_score
         data_type: float64
         description: '{{ doc("col_billing_score") }}'
-        meta:
-          dimension:
-            type: number
+        config:
+          meta:
+            dimension:
+              type: number
 
       - name: support_score
         data_type: float64
         description: '{{ doc("col_support_score") }}'
-        meta:
-          dimension:
-            type: number
+        config:
+          meta:
+            dimension:
+              type: number
 
       - name: acquisition_channel_key
         data_type: int64
         description: '{{ doc("col_acquisition_channel_key") }}'
-        meta:
-          dimension:
-            hidden: true
+        config:
+          meta:
+            dimension:
+              hidden: true
         data_tests:
           - relationships:
               arguments:
@@ -307,17 +333,19 @@ models:
       - name: acquisition_date
         data_type: date
         description: '{{ doc("col_acquisition_date") }}'
-        meta:
-          dimension:
-            type: date
-            time_intervals: ["DAY", "WEEK", "MONTH", "QUARTER", "YEAR"]
+        config:
+          meta:
+            dimension:
+              type: date
+              time_intervals: ["DAY", "WEEK", "MONTH", "QUARTER", "YEAR"]
 
       - name: lifecycle_stage
         data_type: string
         description: '{{ doc("col_lifecycle_stage") }}'
-        meta:
-          dimension:
-            type: string
+        config:
+          meta:
+            dimension:
+              type: string
         data_tests:
           - accepted_values:
               arguments:
@@ -344,14 +372,15 @@ models:
       - name: signup_key
         data_type: int64
         description: '{{ doc("col_signup_key") }}'
-        meta:
-          dimension:
-            hidden: true
-          metrics:
-            signups:
-              type: count_distinct
-              label: "Signups"
-              description: 'Distinct signup events.'
+        config:
+          meta:
+            dimension:
+              hidden: true
+            metrics:
+              signups:
+                type: count_distinct
+                label: "Signups"
+                description: 'Distinct signup events.'
         data_tests:
           - unique
           - not_null
@@ -359,9 +388,10 @@ models:
       - name: event_id
         data_type: string
         description: '{{ doc("col_event_id") }}'
-        meta:
-          dimension:
-            hidden: true
+        config:
+          meta:
+            dimension:
+              hidden: true
         data_tests:
           - unique
           - not_null
@@ -369,18 +399,20 @@ models:
       - name: user_id
         data_type: string
         description: '{{ doc("col_user_id") }}'
-        meta:
-          dimension:
-            hidden: true
+        config:
+          meta:
+            dimension:
+              hidden: true
         data_tests:
           - not_null
 
       - name: user_key
         data_type: int64
         description: '{{ doc("col_user_key") }}'
-        meta:
-          dimension:
-            hidden: true
+        config:
+          meta:
+            dimension:
+              hidden: true
         data_tests:
           - not_null
           - relationships:
@@ -395,9 +427,10 @@ models:
       - name: signup_date_key
         data_type: int64
         description: '{{ doc("col_signup_date_key") }}'
-        meta:
-          dimension:
-            hidden: true
+        config:
+          meta:
+            dimension:
+              hidden: true
         data_tests:
           - not_null
           - relationships:
@@ -412,19 +445,21 @@ models:
       - name: signup_at
         data_type: timestamp
         description: '{{ doc("col_signup_at") }}'
-        meta:
-          dimension:
-            type: timestamp
-            time_intervals: ["DAY", "WEEK", "MONTH", "QUARTER", "YEAR"]
+        config:
+          meta:
+            dimension:
+              type: timestamp
+              time_intervals: ["DAY", "WEEK", "MONTH", "QUARTER", "YEAR"]
         data_tests:
           - not_null
 
       - name: signup_method
         data_type: string
         description: '{{ doc("col_signup_method") }}'
-        meta:
-          dimension:
-            type: string
+        config:
+          meta:
+            dimension:
+              type: string
         data_tests:
           - not_null
           - accepted_values:
@@ -437,18 +472,20 @@ models:
       - name: channel
         data_type: string
         description: '{{ doc("col_channel") }}'
-        meta:
-          dimension:
-            type: string
+        config:
+          meta:
+            dimension:
+              type: string
         data_tests:
           - not_null
 
       - name: channel_key
         data_type: int64
         description: '{{ doc("col_channel_key") }}'
-        meta:
-          dimension:
-            hidden: true
+        config:
+          meta:
+            dimension:
+              hidden: true
         data_tests:
           - not_null
           - relationships:
@@ -463,44 +500,50 @@ models:
       - name: platform
         data_type: string
         description: '{{ doc("col_platform") }}'
-        meta:
-          dimension:
-            type: string
+        config:
+          meta:
+            dimension:
+              type: string
 
       - name: device_type
         data_type: string
         description: '{{ doc("col_device_type") }}'
-        meta:
-          dimension:
-            type: string
+        config:
+          meta:
+            dimension:
+              type: string
 
       - name: browser
         data_type: string
         description: '{{ doc("col_browser") }}'
-        meta:
-          dimension:
-            type: string
+        config:
+          meta:
+            dimension:
+              type: string
 
       - name: utm_source
         data_type: string
         description: '{{ doc("col_utm_source") }}'
-        meta:
-          dimension:
-            type: string
+        config:
+          meta:
+            dimension:
+              type: string
 
       - name: utm_medium
         data_type: string
         description: '{{ doc("col_utm_medium") }}'
-        meta:
-          dimension:
-            type: string
+        config:
+          meta:
+            dimension:
+              type: string
 
       - name: utm_campaign
         data_type: string
         description: '{{ doc("col_utm_campaign") }}'
-        meta:
-          dimension:
-            type: string
+        config:
+          meta:
+            dimension:
+              type: string
 
   - name: fct_activations
     description: '{{ doc("fct_activations") }}'
@@ -518,14 +561,15 @@ models:
       - name: activation_key
         data_type: int64
         description: '{{ doc("col_activation_key") }}'
-        meta:
-          dimension:
-            hidden: true
-          metrics:
-            activations:
-              type: count_distinct
-              label: "Activations"
-              description: 'Distinct activation events — users who completed an activation action within the window.'
+        config:
+          meta:
+            dimension:
+              hidden: true
+            metrics:
+              activations:
+                type: count_distinct
+                label: "Activations"
+                description: 'Distinct activation events — users who completed an activation action within the window.'
         data_tests:
           - unique
           - not_null
@@ -533,9 +577,10 @@ models:
       - name: user_id
         data_type: string
         description: '{{ doc("col_user_id") }}'
-        meta:
-          dimension:
-            hidden: true
+        config:
+          meta:
+            dimension:
+              hidden: true
         data_tests:
           # unique is correct: int_attribution produces exactly one row per user
           # (one-activation-per-user is the business invariant). activation_key
@@ -547,9 +592,10 @@ models:
       - name: user_key
         data_type: int64
         description: '{{ doc("col_user_key") }}'
-        meta:
-          dimension:
-            hidden: true
+        config:
+          meta:
+            dimension:
+              hidden: true
         data_tests:
           - not_null
           - relationships:
@@ -564,9 +610,10 @@ models:
       - name: activation_date_key
         data_type: int64
         description: '{{ doc("col_activation_date_key") }}'
-        meta:
-          dimension:
-            hidden: true
+        config:
+          meta:
+            dimension:
+              hidden: true
         data_tests:
           - not_null
           - relationships:
@@ -581,19 +628,21 @@ models:
       - name: activation_at
         data_type: timestamp
         description: '{{ doc("col_activation_at") }}'
-        meta:
-          dimension:
-            type: timestamp
-            time_intervals: ["DAY", "WEEK", "MONTH", "QUARTER", "YEAR"]
+        config:
+          meta:
+            dimension:
+              type: timestamp
+              time_intervals: ["DAY", "WEEK", "MONTH", "QUARTER", "YEAR"]
         data_tests:
           - not_null
 
       - name: first_touch_channel_key
         data_type: int64
         description: '{{ doc("col_first_touch_channel_key") }}'
-        meta:
-          dimension:
-            hidden: true
+        config:
+          meta:
+            dimension:
+              hidden: true
         data_tests:
           - not_null
           - relationships:
@@ -608,9 +657,10 @@ models:
       - name: last_touch_channel_key
         data_type: int64
         description: '{{ doc("col_last_touch_channel_key") }}'
-        meta:
-          dimension:
-            hidden: true
+        config:
+          meta:
+            dimension:
+              hidden: true
         data_tests:
           - not_null
           - relationships:
@@ -625,18 +675,20 @@ models:
       - name: first_touch_channel
         data_type: string
         description: '{{ doc("col_first_touch_channel") }}'
-        meta:
-          dimension:
-            type: string
+        config:
+          meta:
+            dimension:
+              type: string
         data_tests:
           - not_null
 
       - name: last_touch_channel
         data_type: string
         description: '{{ doc("col_last_touch_channel") }}'
-        meta:
-          dimension:
-            type: string
+        config:
+          meta:
+            dimension:
+              type: string
         data_tests:
           - not_null
 
@@ -656,9 +708,10 @@ models:
       - name: retention_cohort_key
         data_type: int64
         description: '{{ doc("col_retention_cohort_key") }}'
-        meta:
-          dimension:
-            hidden: true
+        config:
+          meta:
+            dimension:
+              hidden: true
         data_tests:
           - unique
           - not_null
@@ -666,19 +719,21 @@ models:
       - name: cohort_week_start_date
         data_type: date
         description: '{{ doc("col_cohort_week_start_date") }}'
-        meta:
-          dimension:
-            type: date
-            time_intervals: ["DAY", "WEEK", "MONTH", "QUARTER", "YEAR"]
+        config:
+          meta:
+            dimension:
+              type: date
+              time_intervals: ["DAY", "WEEK", "MONTH", "QUARTER", "YEAR"]
         data_tests:
           - not_null
 
       - name: cohort_week_date_key
         data_type: int64
         description: '{{ doc("col_cohort_week_date_key") }}'
-        meta:
-          dimension:
-            hidden: true
+        config:
+          meta:
+            dimension:
+              hidden: true
         data_tests:
           - not_null
           - relationships:
@@ -693,9 +748,10 @@ models:
       - name: retention_period
         data_type: string
         description: '{{ doc("col_retention_period") }}'
-        meta:
-          dimension:
-            type: string
+        config:
+          meta:
+            dimension:
+              type: string
         data_tests:
           - not_null
           - accepted_values:
@@ -713,28 +769,31 @@ models:
       - name: period_offset_days
         data_type: int64
         description: '{{ doc("col_period_offset_days") }}'
-        meta:
-          dimension:
-            type: number
+        config:
+          meta:
+            dimension:
+              type: number
         data_tests:
           - not_null
 
       - name: period_end_date
         data_type: date
         description: '{{ doc("col_period_end_date") }}'
-        meta:
-          dimension:
-            type: date
-            time_intervals: ["DAY", "WEEK", "MONTH", "QUARTER", "YEAR"]
+        config:
+          meta:
+            dimension:
+              type: date
+              time_intervals: ["DAY", "WEEK", "MONTH", "QUARTER", "YEAR"]
         data_tests:
           - not_null
 
       - name: period_end_date_key
         data_type: int64
         description: '{{ doc("col_period_end_date_key") }}'
-        meta:
-          dimension:
-            hidden: true
+        config:
+          meta:
+            dimension:
+              hidden: true
         data_tests:
           - not_null
           - relationships:
@@ -750,51 +809,55 @@ models:
       - name: cohort_size
         data_type: int64
         description: '{{ doc("col_cohort_size") }}'
-        meta:
-          dimension:
-            type: number
-          metrics:
-            cohort_size:
-              type: sum
-              label: "Cohort Size"
-              description: 'Sum of users in each cohort window.'
+        config:
+          meta:
+            dimension:
+              type: number
+            metrics:
+              cohort_size:
+                type: sum
+                label: "Cohort Size"
+                description: 'Sum of users in each cohort window.'
         data_tests:
           - not_null
 
       - name: retained_count
         data_type: int64
         description: '{{ doc("col_retained_count") }}'
-        meta:
-          dimension:
-            type: number
-          metrics:
-            retained_count:
-              type: sum
-              label: "Retained Users"
-              description: 'Sum of users retained at each period.'
+        config:
+          meta:
+            dimension:
+              type: number
+            metrics:
+              retained_count:
+                type: sum
+                label: "Retained Users"
+                description: 'Sum of users retained at each period.'
         data_tests:
           - not_null
 
       - name: retention_rate
         data_type: float64
         description: '{{ doc("col_retention_rate") }}'
-        meta:
-          dimension:
-            type: number
-          metrics:
-            retention_rate:
-              type: average
-              label: "Retention Rate"
-              description: 'Mean retention rate across cohorts. Note: cohort_size-weighted mean is preferred for executive reporting.'
+        config:
+          meta:
+            dimension:
+              type: number
+            metrics:
+              retention_rate:
+                type: average
+                label: "Retention Rate"
+                description: 'Mean retention rate across cohorts. Note: cohort_size-weighted mean is preferred for executive reporting.'
         data_tests:
           - not_null
 
       - name: is_period_complete
         data_type: boolean
         description: '{{ doc("col_is_period_complete") }}'
-        meta:
-          dimension:
-            type: boolean
+        config:
+          meta:
+            dimension:
+              type: boolean
         data_tests:
           - not_null
 

--- a/models/marts/marketing/_models.yml
+++ b/models/marts/marketing/_models.yml
@@ -17,9 +17,10 @@ models:
       - name: spend_key
         data_type: int64
         description: '{{ doc("col_spend_key") }}'
-        meta:
-          dimension:
-            hidden: true
+        config:
+          meta:
+            dimension:
+              hidden: true
         data_tests:
           - unique
           - not_null
@@ -27,9 +28,10 @@ models:
       - name: spend_id
         data_type: string
         description: '{{ doc("col_spend_id") }}'
-        meta:
-          dimension:
-            hidden: true
+        config:
+          meta:
+            dimension:
+              hidden: true
         data_tests:
           - unique
           - not_null
@@ -37,9 +39,10 @@ models:
       - name: spend_date_key
         data_type: int64
         description: '{{ doc("col_spend_date_key") }}'
-        meta:
-          dimension:
-            hidden: true
+        config:
+          meta:
+            dimension:
+              hidden: true
         data_tests:
           - not_null
           - relationships:
@@ -54,18 +57,20 @@ models:
       - name: channel
         data_type: string
         description: '{{ doc("col_channel") }}'
-        meta:
-          dimension:
-            type: string
+        config:
+          meta:
+            dimension:
+              type: string
         data_tests:
           - not_null
 
       - name: channel_key
         data_type: int64
         description: '{{ doc("col_channel_key") }}'
-        meta:
-          dimension:
-            hidden: true
+        config:
+          meta:
+            dimension:
+              hidden: true
         data_tests:
           - not_null
           - relationships:
@@ -80,62 +85,68 @@ models:
       - name: campaign_id
         data_type: string
         description: '{{ doc("col_campaign_id") }}'
-        meta:
-          dimension:
-            hidden: true
+        config:
+          meta:
+            dimension:
+              hidden: true
         data_tests:
           - not_null
 
       - name: campaign_name
         data_type: string
         description: '{{ doc("col_campaign_name") }}'
-        meta:
-          dimension:
-            type: string
+        config:
+          meta:
+            dimension:
+              type: string
 
       - name: spend_amount
         data_type: numeric
         description: '{{ doc("col_spend_amount") }}'
-        meta:
-          dimension:
-            type: number
-          metrics:
-            marketing_spend:
-              type: sum
-              label: "Marketing Spend"
-              description: 'Sum of marketing spend.'
+        config:
+          meta:
+            dimension:
+              type: number
+            metrics:
+              marketing_spend:
+                type: sum
+                label: "Marketing Spend"
+                description: 'Sum of marketing spend.'
         data_tests:
           - not_null
 
       - name: currency
         data_type: string
         description: '{{ doc("col_currency") }}'
-        meta:
-          dimension:
-            type: string
+        config:
+          meta:
+            dimension:
+              type: string
         data_tests:
           - not_null
 
       - name: impressions
         data_type: int64
         description: '{{ doc("col_impressions") }}'
-        meta:
-          dimension:
-            type: number
-          metrics:
-            impressions:
-              type: sum
-              label: "Impressions"
-              description: 'Sum of ad impressions.'
+        config:
+          meta:
+            dimension:
+              type: number
+            metrics:
+              impressions:
+                type: sum
+                label: "Impressions"
+                description: 'Sum of ad impressions.'
 
       - name: clicks
         data_type: int64
         description: '{{ doc("col_clicks") }}'
-        meta:
-          dimension:
-            type: number
-          metrics:
-            clicks:
-              type: sum
-              label: "Clicks"
-              description: 'Sum of ad clicks.'
+        config:
+          meta:
+            dimension:
+              type: number
+            metrics:
+              clicks:
+                type: sum
+                label: "Clicks"
+                description: 'Sum of ad clicks.'

--- a/models/marts/marketing/_models.yml
+++ b/models/marts/marketing/_models.yml
@@ -99,10 +99,11 @@ models:
         meta:
           dimension:
             type: number
-          metric:
-            type: sum
-            label: "Marketing Spend"
-            description: 'Sum of marketing spend.'
+          metrics:
+            marketing_spend:
+              type: sum
+              label: "Marketing Spend"
+              description: 'Sum of marketing spend.'
         data_tests:
           - not_null
 
@@ -121,10 +122,11 @@ models:
         meta:
           dimension:
             type: number
-          metric:
-            type: sum
-            label: "Impressions"
-            description: 'Sum of ad impressions.'
+          metrics:
+            impressions:
+              type: sum
+              label: "Impressions"
+              description: 'Sum of ad impressions.'
 
       - name: clicks
         data_type: int64
@@ -132,7 +134,8 @@ models:
         meta:
           dimension:
             type: number
-          metric:
-            type: sum
-            label: "Clicks"
-            description: 'Sum of ad clicks.'
+          metrics:
+            clicks:
+              type: sum
+              label: "Clicks"
+              description: 'Sum of ad clicks.'

--- a/models/marts/product/_models.yml
+++ b/models/marts/product/_models.yml
@@ -17,9 +17,10 @@ models:
       - name: session_key
         data_type: int64
         description: '{{ doc("col_session_key") }}'
-        meta:
-          dimension:
-            hidden: true
+        config:
+          meta:
+            dimension:
+              hidden: true
         data_tests:
           - unique
           - not_null
@@ -27,9 +28,10 @@ models:
       - name: session_id
         data_type: string
         description: '{{ doc("col_session_id") }}'
-        meta:
-          dimension:
-            hidden: true
+        config:
+          meta:
+            dimension:
+              hidden: true
         data_tests:
           - unique
           - not_null
@@ -37,9 +39,10 @@ models:
       - name: session_date_key
         data_type: int64
         description: '{{ doc("col_session_date_key") }}'
-        meta:
-          dimension:
-            hidden: true
+        config:
+          meta:
+            dimension:
+              hidden: true
         data_tests:
           - not_null
           - relationships:
@@ -54,65 +57,74 @@ models:
       - name: platform
         data_type: string
         description: '{{ doc("col_platform") }}'
-        meta:
-          dimension:
-            type: string
+        config:
+          meta:
+            dimension:
+              type: string
 
       - name: device_type
         data_type: string
         description: '{{ doc("col_device_type") }}'
-        meta:
-          dimension:
-            type: string
+        config:
+          meta:
+            dimension:
+              type: string
 
       - name: browser
         data_type: string
         description: '{{ doc("col_browser") }}'
-        meta:
-          dimension:
-            type: string
+        config:
+          meta:
+            dimension:
+              type: string
 
       - name: utm_source
         data_type: string
         description: '{{ doc("col_utm_source") }}'
-        meta:
-          dimension:
-            type: string
+        config:
+          meta:
+            dimension:
+              type: string
 
       - name: utm_medium
         data_type: string
         description: '{{ doc("col_utm_medium") }}'
-        meta:
-          dimension:
-            type: string
+        config:
+          meta:
+            dimension:
+              type: string
 
       - name: utm_campaign
         data_type: string
         description: '{{ doc("col_utm_campaign") }}'
-        meta:
-          dimension:
-            type: string
+        config:
+          meta:
+            dimension:
+              type: string
 
       - name: session_duration_seconds
         data_type: int64
         description: '{{ doc("col_session_duration_seconds") }}'
-        meta:
-          dimension:
-            type: number
+        config:
+          meta:
+            dimension:
+              type: number
 
       - name: event_count
         data_type: int64
         description: '{{ doc("col_event_count") }}'
-        meta:
-          dimension:
-            type: number
+        config:
+          meta:
+            dimension:
+              type: number
 
       - name: page_view_count
         data_type: int64
         description: '{{ doc("col_page_view_count") }}'
-        meta:
-          dimension:
-            type: number
+        config:
+          meta:
+            dimension:
+              type: number
 
   - name: dim_experiments
     description: '{{ doc("dim_experiments") }}'
@@ -130,9 +142,10 @@ models:
       - name: experiment_key
         data_type: int64
         description: '{{ doc("col_experiment_key") }}'
-        meta:
-          dimension:
-            hidden: true
+        config:
+          meta:
+            dimension:
+              hidden: true
         data_tests:
           - unique
           - not_null
@@ -140,9 +153,10 @@ models:
       - name: experiment_id
         data_type: string
         description: '{{ doc("col_experiment_id") }}'
-        meta:
-          dimension:
-            hidden: true
+        config:
+          meta:
+            dimension:
+              hidden: true
         data_tests:
           - unique
           - not_null
@@ -150,18 +164,20 @@ models:
       - name: experiment_name
         data_type: string
         description: '{{ doc("col_experiment_name") }}'
-        meta:
-          dimension:
-            type: string
+        config:
+          meta:
+            dimension:
+              type: string
         data_tests:
           - not_null
 
       - name: status
         data_type: string
         description: '{{ doc("col_experiment_status") }}'
-        meta:
-          dimension:
-            type: string
+        config:
+          meta:
+            dimension:
+              type: string
         data_tests:
           - not_null
           - accepted_values:
@@ -174,27 +190,30 @@ models:
       - name: start_date
         data_type: date
         description: '{{ doc("col_experiment_start_date") }}'
-        meta:
-          dimension:
-            type: date
-            time_intervals: ["DAY", "WEEK", "MONTH", "QUARTER", "YEAR"]
+        config:
+          meta:
+            dimension:
+              type: date
+              time_intervals: ["DAY", "WEEK", "MONTH", "QUARTER", "YEAR"]
         data_tests:
           - not_null
 
       - name: end_date
         data_type: date
         description: '{{ doc("col_experiment_end_date") }}'
-        meta:
-          dimension:
-            type: date
-            time_intervals: ["DAY", "WEEK", "MONTH", "QUARTER", "YEAR"]
+        config:
+          meta:
+            dimension:
+              type: date
+              time_intervals: ["DAY", "WEEK", "MONTH", "QUARTER", "YEAR"]
 
       - name: description
         data_type: string
         description: '{{ doc("col_experiment_description") }}'
-        meta:
-          dimension:
-            type: string
+        config:
+          meta:
+            dimension:
+              type: string
 
   - name: bridge_user_experiments
     description: '{{ doc("bridge_user_experiments") }}'
@@ -212,9 +231,10 @@ models:
       - name: user_key
         data_type: int64
         description: '{{ doc("col_user_key") }}'
-        meta:
-          dimension:
-            hidden: true
+        config:
+          meta:
+            dimension:
+              hidden: true
         data_tests:
           - not_null
           - relationships:
@@ -229,18 +249,20 @@ models:
       - name: user_id
         data_type: string
         description: '{{ doc("col_user_id") }}'
-        meta:
-          dimension:
-            hidden: true
+        config:
+          meta:
+            dimension:
+              hidden: true
         data_tests:
           - not_null
 
       - name: experiment_key
         data_type: int64
         description: '{{ doc("col_experiment_key") }}'
-        meta:
-          dimension:
-            hidden: true
+        config:
+          meta:
+            dimension:
+              hidden: true
         data_tests:
           - not_null
           - relationships:
@@ -255,19 +277,21 @@ models:
       - name: variant
         data_type: string
         description: '{{ doc("col_variant") }}'
-        meta:
-          dimension:
-            type: string
+        config:
+          meta:
+            dimension:
+              type: string
         data_tests:
           - not_null
 
       - name: first_exposure_at
         data_type: timestamp
         description: '{{ doc("col_first_exposure_at") }}'
-        meta:
-          dimension:
-            type: timestamp
-            time_intervals: ["DAY", "WEEK", "MONTH", "QUARTER", "YEAR"]
+        config:
+          meta:
+            dimension:
+              type: timestamp
+              time_intervals: ["DAY", "WEEK", "MONTH", "QUARTER", "YEAR"]
         data_tests:
           - not_null
 
@@ -294,14 +318,15 @@ models:
       - name: feature_usage_key
         data_type: int64
         description: '{{ doc("col_feature_usage_key") }}'
-        meta:
-          dimension:
-            hidden: true
-          metrics:
-            feature_usages:
-              type: count_distinct
-              label: "Feature Usages"
-              description: 'Distinct feature-use events.'
+        config:
+          meta:
+            dimension:
+              hidden: true
+            metrics:
+              feature_usages:
+                type: count_distinct
+                label: "Feature Usages"
+                description: 'Distinct feature-use events.'
         data_tests:
           - unique
           - not_null
@@ -309,9 +334,10 @@ models:
       - name: event_id
         data_type: string
         description: '{{ doc("col_event_id") }}'
-        meta:
-          dimension:
-            hidden: true
+        config:
+          meta:
+            dimension:
+              hidden: true
         data_tests:
           - unique
           - not_null
@@ -319,18 +345,20 @@ models:
       - name: user_id
         data_type: string
         description: '{{ doc("col_user_id") }}'
-        meta:
-          dimension:
-            hidden: true
+        config:
+          meta:
+            dimension:
+              hidden: true
         data_tests:
           - not_null
 
       - name: user_key
         data_type: int64
         description: '{{ doc("col_user_key") }}'
-        meta:
-          dimension:
-            hidden: true
+        config:
+          meta:
+            dimension:
+              hidden: true
         data_tests:
           - not_null
           - relationships:
@@ -345,16 +373,18 @@ models:
       - name: account_id
         data_type: string
         description: '{{ doc("col_account_id") }}'
-        meta:
-          dimension:
-            hidden: true
+        config:
+          meta:
+            dimension:
+              hidden: true
 
       - name: account_key
         data_type: int64
         description: '{{ doc("col_account_key") }}'
-        meta:
-          dimension:
-            hidden: true
+        config:
+          meta:
+            dimension:
+              hidden: true
         data_tests:
           - relationships:
               arguments:
@@ -369,9 +399,10 @@ models:
       - name: usage_date_key
         data_type: int64
         description: '{{ doc("col_usage_date_key") }}'
-        meta:
-          dimension:
-            hidden: true
+        config:
+          meta:
+            dimension:
+              hidden: true
         data_tests:
           - not_null
           - relationships:
@@ -386,19 +417,21 @@ models:
       - name: usage_at
         data_type: timestamp
         description: '{{ doc("col_usage_at") }}'
-        meta:
-          dimension:
-            type: timestamp
-            time_intervals: ["DAY", "WEEK", "MONTH", "QUARTER", "YEAR"]
+        config:
+          meta:
+            dimension:
+              type: timestamp
+              time_intervals: ["DAY", "WEEK", "MONTH", "QUARTER", "YEAR"]
         data_tests:
           - not_null
 
       - name: feature_name
         data_type: string
         description: '{{ doc("col_feature_name") }}'
-        meta:
-          dimension:
-            type: string
+        config:
+          meta:
+            dimension:
+              type: string
         data_tests:
           - not_null
           - accepted_values:
@@ -418,23 +451,26 @@ models:
       - name: feature_duration_seconds
         data_type: int64
         description: '{{ doc("col_feature_duration_seconds") }}'
-        meta:
-          dimension:
-            type: number
+        config:
+          meta:
+            dimension:
+              type: number
 
       - name: platform
         data_type: string
         description: '{{ doc("col_platform") }}'
-        meta:
-          dimension:
-            type: string
+        config:
+          meta:
+            dimension:
+              type: string
 
       - name: device_type
         data_type: string
         description: '{{ doc("col_device_type") }}'
-        meta:
-          dimension:
-            type: string
+        config:
+          meta:
+            dimension:
+              type: string
 
   - name: fct_sessions
     description: '{{ doc("fct_sessions") }}'
@@ -452,14 +488,15 @@ models:
       - name: session_key
         data_type: int64
         description: '{{ doc("col_session_key") }}'
-        meta:
-          dimension:
-            hidden: true
-          metrics:
-            sessions:
-              type: count_distinct
-              label: "Sessions"
-              description: 'Distinct session count.'
+        config:
+          meta:
+            dimension:
+              hidden: true
+            metrics:
+              sessions:
+                type: count_distinct
+                label: "Sessions"
+                description: 'Distinct session count.'
         data_tests:
           - unique
           - not_null
@@ -475,9 +512,10 @@ models:
       - name: session_id
         data_type: string
         description: '{{ doc("col_session_id") }}'
-        meta:
-          dimension:
-            hidden: true
+        config:
+          meta:
+            dimension:
+              hidden: true
         data_tests:
           - unique
           - not_null
@@ -485,16 +523,18 @@ models:
       - name: user_id
         data_type: string
         description: '{{ doc("col_user_id") }}'
-        meta:
-          dimension:
-            hidden: true
+        config:
+          meta:
+            dimension:
+              hidden: true
 
       - name: user_key
         data_type: int64
         description: '{{ doc("col_user_key") }}'
-        meta:
-          dimension:
-            hidden: true
+        config:
+          meta:
+            dimension:
+              hidden: true
         data_tests:
           - relationships:
               arguments:
@@ -509,9 +549,10 @@ models:
       - name: session_date_key
         data_type: int64
         description: '{{ doc("col_session_date_key") }}'
-        meta:
-          dimension:
-            hidden: true
+        config:
+          meta:
+            dimension:
+              hidden: true
         data_tests:
           - not_null
           - relationships:
@@ -526,99 +567,110 @@ models:
       - name: session_start_at
         data_type: timestamp
         description: '{{ doc("col_session_start_at") }}'
-        meta:
-          dimension:
-            type: timestamp
-            time_intervals: ["DAY", "WEEK", "MONTH", "QUARTER", "YEAR"]
+        config:
+          meta:
+            dimension:
+              type: timestamp
+              time_intervals: ["DAY", "WEEK", "MONTH", "QUARTER", "YEAR"]
         data_tests:
           - not_null
 
       - name: session_end_at
         data_type: timestamp
         description: '{{ doc("col_session_end_at") }}'
-        meta:
-          dimension:
-            type: timestamp
-            time_intervals: ["DAY", "WEEK", "MONTH", "QUARTER", "YEAR"]
+        config:
+          meta:
+            dimension:
+              type: timestamp
+              time_intervals: ["DAY", "WEEK", "MONTH", "QUARTER", "YEAR"]
         data_tests:
           - not_null
 
       - name: session_duration_seconds
         data_type: int64
         description: '{{ doc("col_session_duration_seconds") }}'
-        meta:
-          dimension:
-            type: number
-          metrics:
-            avg_session_duration_seconds:
-              type: average
-              label: "Avg Session Duration (s)"
-              description: 'Mean session length in seconds.'
+        config:
+          meta:
+            dimension:
+              type: number
+            metrics:
+              avg_session_duration_seconds:
+                type: average
+                label: "Avg Session Duration (s)"
+                description: 'Mean session length in seconds.'
         data_tests:
           - not_null
 
       - name: event_count
         data_type: int64
         description: '{{ doc("col_event_count") }}'
-        meta:
-          dimension:
-            type: number
-          metrics:
-            events:
-              type: sum
-              label: "Events"
-              description: 'Sum of events across sessions.'
+        config:
+          meta:
+            dimension:
+              type: number
+            metrics:
+              events:
+                type: sum
+                label: "Events"
+                description: 'Sum of events across sessions.'
         data_tests:
           - not_null
 
       - name: page_view_count
         data_type: int64
         description: '{{ doc("col_page_view_count") }}'
-        meta:
-          dimension:
-            type: number
+        config:
+          meta:
+            dimension:
+              type: number
 
       - name: platform
         data_type: string
         description: '{{ doc("col_platform") }}'
-        meta:
-          dimension:
-            type: string
+        config:
+          meta:
+            dimension:
+              type: string
 
       - name: device_type
         data_type: string
         description: '{{ doc("col_device_type") }}'
-        meta:
-          dimension:
-            type: string
+        config:
+          meta:
+            dimension:
+              type: string
 
       - name: browser
         data_type: string
         description: '{{ doc("col_browser") }}'
-        meta:
-          dimension:
-            type: string
+        config:
+          meta:
+            dimension:
+              type: string
 
       - name: utm_source
         data_type: string
         description: '{{ doc("col_utm_source") }}'
-        meta:
-          dimension:
-            type: string
+        config:
+          meta:
+            dimension:
+              type: string
 
       - name: utm_medium
         data_type: string
         description: '{{ doc("col_utm_medium") }}'
-        meta:
-          dimension:
-            type: string
+        config:
+          meta:
+            dimension:
+              type: string
 
       - name: utm_campaign
         data_type: string
         description: '{{ doc("col_utm_campaign") }}'
-        meta:
-          dimension:
-            type: string
+        config:
+          meta:
+            dimension:
+              type: string
 
   - name: fct_experiment_exposures
     description: '{{ doc("fct_experiment_exposures") }}'
@@ -636,18 +688,20 @@ models:
       - name: user_id
         data_type: string
         description: '{{ doc("col_user_id") }}'
-        meta:
-          dimension:
-            hidden: true
+        config:
+          meta:
+            dimension:
+              hidden: true
         data_tests:
           - not_null
 
       - name: user_key
         data_type: int64
         description: '{{ doc("col_user_key") }}'
-        meta:
-          dimension:
-            hidden: true
+        config:
+          meta:
+            dimension:
+              hidden: true
         data_tests:
           - not_null
           - relationships:
@@ -662,18 +716,20 @@ models:
       - name: experiment_id
         data_type: string
         description: '{{ doc("col_experiment_id") }}'
-        meta:
-          dimension:
-            hidden: true
+        config:
+          meta:
+            dimension:
+              hidden: true
         data_tests:
           - not_null
 
       - name: experiment_key
         data_type: int64
         description: '{{ doc("col_experiment_key") }}'
-        meta:
-          dimension:
-            hidden: true
+        config:
+          meta:
+            dimension:
+              hidden: true
         data_tests:
           - not_null
           - relationships:
@@ -688,9 +744,10 @@ models:
       - name: variant
         data_type: string
         description: '{{ doc("col_variant") }}'
-        meta:
-          dimension:
-            type: string
+        config:
+          meta:
+            dimension:
+              type: string
         data_tests:
           - not_null
           - accepted_values:
@@ -702,19 +759,21 @@ models:
       - name: first_exposure_at
         data_type: timestamp
         description: '{{ doc("col_first_exposure_at") }}'
-        meta:
-          dimension:
-            type: timestamp
-            time_intervals: ["DAY", "WEEK", "MONTH", "QUARTER", "YEAR"]
+        config:
+          meta:
+            dimension:
+              type: timestamp
+              time_intervals: ["DAY", "WEEK", "MONTH", "QUARTER", "YEAR"]
         data_tests:
           - not_null
 
       - name: exposure_date_key
         data_type: int64
         description: '{{ doc("col_exposure_date_key") }}'
-        meta:
-          dimension:
-            hidden: true
+        config:
+          meta:
+            dimension:
+              hidden: true
         data_tests:
           - not_null
           - relationships:
@@ -729,26 +788,29 @@ models:
       - name: converted
         data_type: boolean
         description: '{{ doc("col_converted") }}'
-        meta:
-          dimension:
-            type: boolean
+        config:
+          meta:
+            dimension:
+              type: boolean
         data_tests:
           - not_null
 
       - name: conversion_at
         data_type: timestamp
         description: '{{ doc("col_conversion_at") }}'
-        meta:
-          dimension:
-            type: timestamp
-            time_intervals: ["DAY", "WEEK", "MONTH", "QUARTER", "YEAR"]
+        config:
+          meta:
+            dimension:
+              type: timestamp
+              time_intervals: ["DAY", "WEEK", "MONTH", "QUARTER", "YEAR"]
 
       - name: exposure_duration_hours
         data_type: int64
         description: '{{ doc("col_exposure_duration_hours") }}'
-        meta:
-          dimension:
-            type: number
+        config:
+          meta:
+            dimension:
+              type: number
         data_tests:
           - not_null
 

--- a/models/marts/product/_models.yml
+++ b/models/marts/product/_models.yml
@@ -297,10 +297,11 @@ models:
         meta:
           dimension:
             hidden: true
-          metric:
-            type: count_distinct
-            label: "Feature Usages"
-            description: 'Distinct feature-use events.'
+          metrics:
+            feature_usages:
+              type: count_distinct
+              label: "Feature Usages"
+              description: 'Distinct feature-use events.'
         data_tests:
           - unique
           - not_null
@@ -454,10 +455,11 @@ models:
         meta:
           dimension:
             hidden: true
-          metric:
-            type: count_distinct
-            label: "Sessions"
-            description: 'Distinct session count.'
+          metrics:
+            sessions:
+              type: count_distinct
+              label: "Sessions"
+              description: 'Distinct session count.'
         data_tests:
           - unique
           - not_null
@@ -547,10 +549,11 @@ models:
         meta:
           dimension:
             type: number
-          metric:
-            type: average
-            label: "Avg Session Duration (s)"
-            description: 'Mean session length in seconds.'
+          metrics:
+            avg_session_duration_seconds:
+              type: average
+              label: "Avg Session Duration (s)"
+              description: 'Mean session length in seconds.'
         data_tests:
           - not_null
 
@@ -560,10 +563,11 @@ models:
         meta:
           dimension:
             type: number
-          metric:
-            type: sum
-            label: "Events"
-            description: 'Sum of events across sessions.'
+          metrics:
+            events:
+              type: sum
+              label: "Events"
+              description: 'Sum of events across sessions.'
         data_tests:
           - not_null
 

--- a/models/marts/support/_models.yml
+++ b/models/marts/support/_models.yml
@@ -20,10 +20,11 @@ models:
         meta:
           dimension:
             hidden: true
-          metric:
-            type: count_distinct
-            label: "Tickets"
-            description: 'Distinct support tickets.'
+          metrics:
+            tickets:
+              type: count_distinct
+              label: "Tickets"
+              description: 'Distinct support tickets.'
         data_tests:
           - unique
           - not_null
@@ -180,10 +181,11 @@ models:
         meta:
           dimension:
             type: number
-          metric:
-            type: average
-            label: "Avg CSAT"
-            description: 'Mean customer-satisfaction score (1–5). Null responses excluded.'
+          metrics:
+            avg_csat:
+              type: average
+              label: "Avg CSAT"
+              description: 'Mean customer-satisfaction score (1–5). Null responses excluded.'
 
       - name: resolution_time_hours
         data_type: float64
@@ -191,10 +193,11 @@ models:
         meta:
           dimension:
             type: number
-          metric:
-            type: average
-            label: "Avg Resolution Time (h)"
-            description: 'Mean ticket resolution time in hours. Includes only resolved tickets.'
+          metrics:
+            avg_resolution_time_hours:
+              type: average
+              label: "Avg Resolution Time (h)"
+              description: 'Mean ticket resolution time in hours. Includes only resolved tickets.'
 
       - name: first_response_hours
         data_type: float64

--- a/models/marts/support/_models.yml
+++ b/models/marts/support/_models.yml
@@ -17,14 +17,15 @@ models:
       - name: ticket_key
         data_type: int64
         description: '{{ doc("col_ticket_key") }}'
-        meta:
-          dimension:
-            hidden: true
-          metrics:
-            tickets:
-              type: count_distinct
-              label: "Tickets"
-              description: 'Distinct support tickets.'
+        config:
+          meta:
+            dimension:
+              hidden: true
+            metrics:
+              tickets:
+                type: count_distinct
+                label: "Tickets"
+                description: 'Distinct support tickets.'
         data_tests:
           - unique
           - not_null
@@ -32,9 +33,10 @@ models:
       - name: ticket_id
         data_type: string
         description: '{{ doc("col_ticket_id") }}'
-        meta:
-          dimension:
-            hidden: true
+        config:
+          meta:
+            dimension:
+              hidden: true
         data_tests:
           - unique
           - not_null
@@ -42,18 +44,20 @@ models:
       - name: user_id
         data_type: string
         description: '{{ doc("col_user_id") }}'
-        meta:
-          dimension:
-            hidden: true
+        config:
+          meta:
+            dimension:
+              hidden: true
         data_tests:
           - not_null
 
       - name: user_key
         data_type: int64
         description: '{{ doc("col_user_key") }}'
-        meta:
-          dimension:
-            hidden: true
+        config:
+          meta:
+            dimension:
+              hidden: true
         data_tests:
           - not_null
           - relationships:
@@ -68,18 +72,20 @@ models:
       - name: account_id
         data_type: string
         description: '{{ doc("col_account_id") }}'
-        meta:
-          dimension:
-            hidden: true
+        config:
+          meta:
+            dimension:
+              hidden: true
         data_tests:
           - not_null
 
       - name: account_key
         data_type: int64
         description: '{{ doc("col_account_key") }}'
-        meta:
-          dimension:
-            hidden: true
+        config:
+          meta:
+            dimension:
+              hidden: true
         data_tests:
           - not_null
           - relationships:
@@ -94,9 +100,10 @@ models:
       - name: created_date_key
         data_type: int64
         description: '{{ doc("col_created_date_key") }}'
-        meta:
-          dimension:
-            hidden: true
+        config:
+          meta:
+            dimension:
+              hidden: true
         data_tests:
           - not_null
           - relationships:
@@ -111,27 +118,30 @@ models:
       - name: created_at
         data_type: timestamp
         description: '{{ doc("col_created_at") }}'
-        meta:
-          dimension:
-            type: timestamp
-            time_intervals: ["DAY", "WEEK", "MONTH", "QUARTER", "YEAR"]
+        config:
+          meta:
+            dimension:
+              type: timestamp
+              time_intervals: ["DAY", "WEEK", "MONTH", "QUARTER", "YEAR"]
         data_tests:
           - not_null
 
       - name: resolved_at
         data_type: timestamp
         description: '{{ doc("col_resolved_at") }}'
-        meta:
-          dimension:
-            type: timestamp
-            time_intervals: ["DAY", "WEEK", "MONTH", "QUARTER", "YEAR"]
+        config:
+          meta:
+            dimension:
+              type: timestamp
+              time_intervals: ["DAY", "WEEK", "MONTH", "QUARTER", "YEAR"]
 
       - name: category
         data_type: string
         description: '{{ doc("col_category") }}'
-        meta:
-          dimension:
-            type: string
+        config:
+          meta:
+            dimension:
+              type: string
         data_tests:
           - not_null
           - accepted_values:
@@ -146,9 +156,10 @@ models:
       - name: priority
         data_type: string
         description: '{{ doc("col_priority") }}'
-        meta:
-          dimension:
-            type: string
+        config:
+          meta:
+            dimension:
+              type: string
         data_tests:
           - not_null
           - accepted_values:
@@ -162,9 +173,10 @@ models:
       - name: status
         data_type: string
         description: '{{ doc("col_ticket_status") }}'
-        meta:
-          dimension:
-            type: string
+        config:
+          meta:
+            dimension:
+              type: string
         data_tests:
           - not_null
           - accepted_values:
@@ -178,39 +190,43 @@ models:
       - name: csat_score
         data_type: int64
         description: '{{ doc("col_csat_score") }}'
-        meta:
-          dimension:
-            type: number
-          metrics:
-            avg_csat:
-              type: average
-              label: "Avg CSAT"
-              description: 'Mean customer-satisfaction score (1–5). Null responses excluded.'
+        config:
+          meta:
+            dimension:
+              type: number
+            metrics:
+              avg_csat:
+                type: average
+                label: "Avg CSAT"
+                description: 'Mean customer-satisfaction score (1–5). Null responses excluded.'
 
       - name: resolution_time_hours
         data_type: float64
         description: '{{ doc("col_resolution_time_hours") }}'
-        meta:
-          dimension:
-            type: number
-          metrics:
-            avg_resolution_time_hours:
-              type: average
-              label: "Avg Resolution Time (h)"
-              description: 'Mean ticket resolution time in hours. Includes only resolved tickets.'
+        config:
+          meta:
+            dimension:
+              type: number
+            metrics:
+              avg_resolution_time_hours:
+                type: average
+                label: "Avg Resolution Time (h)"
+                description: 'Mean ticket resolution time in hours. Includes only resolved tickets.'
 
       - name: first_response_hours
         data_type: float64
         description: '{{ doc("col_first_response_hours") }}'
-        meta:
-          dimension:
-            type: number
+        config:
+          meta:
+            dimension:
+              type: number
 
       - name: is_resolved
         data_type: boolean
         description: '{{ doc("col_is_resolved") }}'
-        meta:
-          dimension:
-            type: boolean
+        config:
+          meta:
+            dimension:
+              type: boolean
         data_tests:
           - not_null


### PR DESCRIPTION
## Summary

Follow-up fixes to the Lightdash metric annotations from joeljohn07/b2b-saas-dbt#97. Verified end-to-end against a running self-hosted Lightdash instance (v0.2914.0).

## What changed

### Commit 1 (\`90481c6\`): metric → metrics.<name>

Lightdash expects metric annotations under \`meta.metrics\` (plural, dict-keyed by metric name), not \`meta.metric\` (singular). With the wrong key, Lightdash parsed annotations but the Metrics section in the explorer was empty.

Rewrote all 23 column-level metric annotations across the 5 mart \`_models.yml\` files. Metric-name keys match Lightdash conventions (snake_case, descriptive).

### Commit 2 (\`24bb94a\`): nest column-level meta under config.meta

Lightdash's official jaffle-shop demo (lightdash/lightdash/examples/full-jaffle-shop-demo) uses \`config.meta\` at column level for both dimensions and metrics. Our top-level \`meta\` at column level worked for dimensions in this Lightdash version but silently dropped metrics.

Wrapped every column-level \`meta:\` block in \`config:\` (8 spaces) and indented contents +2 spaces. 198 columns rewritten.

## Verification

YAML parses cleanly across all 5 mart files. Lightdash refresh-dbt picks up the new structure and stores it correctly in its cached_explores table.

### Known limitation (Lightdash 0.2914.0)

Even after both fixes, Lightdash 0.2914.0 still doesn't surface column-level metrics in the explorer — the cached_explore table shows \`metrics: {}\` for every mart. Format matches Lightdash's own jaffle-shop demo verbatim; reason for non-discovery is unclear (Lightdash version bug or undocumented requirement).

Filed as a follow-up. Dimensions DO surface correctly (198 dimensions across 17 marts). Lightdash explores are functional with ad-hoc metrics defined via the UI.