### PR TITLE
fix: rename 5 metrics to avoid dimension-name collisions

### DIFF
--- a/models/marts/core/_models.yml
+++ b/models/marts/core/_models.yml
@@ -814,9 +814,9 @@ models:
             dimension:
               type: number
             metrics:
-              cohort_size:
+              total_cohort_size:
                 type: sum
-                label: "Cohort Size"
+                label: "Total Cohort Size"
                 description: 'Sum of users in each cohort window.'
         data_tests:
           - not_null
@@ -829,9 +829,9 @@ models:
             dimension:
               type: number
             metrics:
-              retained_count:
+              total_retained_users:
                 type: sum
-                label: "Retained Users"
+                label: "Total Retained Users"
                 description: 'Sum of users retained at each period.'
         data_tests:
           - not_null
@@ -844,9 +844,9 @@ models:
             dimension:
               type: number
             metrics:
-              retention_rate:
+              avg_retention_rate:
                 type: average
-                label: "Retention Rate"
+                label: "Avg Retention Rate"
                 description: 'Mean retention rate across cohorts. Note: cohort_size-weighted mean is preferred for executive reporting.'
         data_tests:
           - not_null

--- a/models/marts/marketing/_models.yml
+++ b/models/marts/marketing/_models.yml
@@ -133,9 +133,9 @@ models:
             dimension:
               type: number
             metrics:
-              impressions:
+              total_impressions:
                 type: sum
-                label: "Impressions"
+                label: "Total Impressions"
                 description: 'Sum of ad impressions.'
 
       - name: clicks
@@ -146,7 +146,7 @@ models:
             dimension:
               type: number
             metrics:
-              clicks:
+              total_clicks:
                 type: sum
-                label: "Clicks"
+                label: "Total Clicks"
                 description: 'Sum of ad clicks.'


### PR DESCRIPTION
## Summary

Lightdash silently drops metrics whose name matches an existing dimension name on the same model (see translator.ts:952 — DUPLICATE_FIELD_NAME warning, metric deleted, dimension takes priority).

Five metrics in \`fct_retention_cohorts\` and \`fct_marketing_spend\` were colliding with their underlying column dimensions and disappearing from the explore. The cached_explores table showed 18/23 metrics across the marts (these 5 missing).

## Renames

Snake_case with descriptive prefix to disambiguate from the dimension. Matches the convention from Lightdash's official jaffle-shop demo (e.g., \`total_passenger_volume\`, \`total_campaign_spend\`, \`campaign_count\`).

| Model | Old metric name | New metric name | Label |
|---|---|---|---|
| \`fct_retention_cohorts\` | \`cohort_size\` | \`total_cohort_size\` | \"Total Cohort Size\" |
| \`fct_retention_cohorts\` | \`retained_count\` | \`total_retained_users\` | \"Total Retained Users\" |
| \`fct_retention_cohorts\` | \`retention_rate\` | \`avg_retention_rate\` | \"Avg Retention Rate\" |
| \`fct_marketing_spend\` | \`impressions\` | \`total_impressions\` | \"Total Impressions\" |
| \`fct_marketing_spend\` | \`clicks\` | \`total_clicks\` | \"Total Clicks\" |

## Verified end-to-end

Refreshed dbt in the running Lightdash instance after these changes. Latest compile log shows \`metricsCount: 23\` (up from 18). Per-mart breakdown matches expected:

\`\`\`
dim_accounts          3
fct_invoices          3
fct_marketing_spend   3  ← was 1
fct_retention_cohorts 3  ← was 0
fct_sessions          3
fct_support_tickets   3
fct_activations       1
fct_feature_usage     1
fct_mrr_movements     1
fct_signups           1
fct_subscriptions     1
                    ---
                     23
\`\`\`